### PR TITLE
chore: push correct tags to ECR repository

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -223,7 +223,7 @@ jobs:
         run: |
           ./gradlew bootBuildImage -x bootJar --imageName=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY
+          docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
 
   deploy-preprod:
     name: Deploy pre-production configured service
@@ -265,15 +265,6 @@ jobs:
           cluster: tis-preprod
           wait-for-service-stability: true
 
-      - name: Push stable tag image to Amazon ECR
-        env:
-          ECR_REPOSITORY: ${{ github.event.repository.name }}
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} $ECR_REGISTRY/$ECR_REPOSITORY:stable
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY
-
   deploy-prod:
     name: Deploy production configured service
     runs-on: ubuntu-latest
@@ -304,7 +295,7 @@ jobs:
         with:
           task-definition: .aws/task-definition-prod.json
           container-name: ${{ github.event.repository.name }}
-          image: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:stable
+          image: ${{ steps.login-ecr.outputs.registry }}/${{ github.event.repository.name }}:${{ github.sha }}
 
       - name: Deploy Amazon ECS task definition to prod
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1


### PR DESCRIPTION
The workflow only pushes the `latest` tag before deploying to pre-prod,
but the image is expected to be tagged with the commit sha. Add the
`--all-tags` flag to the Docker push command.

The `stable` tag is used in the microservice template project but is not
used in any `tis-trainee` workflows, remove it for consistency and use
the commit sha directly instead.

TIS21-3337
TIS21-3343