### PR TITLE
fix: change context path to match TIS deployment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.0.1"
+version = "0.0.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 server:
   port: 8208
   servlet:
-    context-path: /user-management
+    context-path: /trainee-user-management
 
 sentry:
   dsn: ${SENTRY_DSN:}


### PR DESCRIPTION
When deploying in to the TIS infrastructure the path is referred to as
`trainee-user-management` to avoid confusion with the existing user
management service.
Change this service's context path to `trainee-user-management` to
simplify the API Gateway mapping for this service.

TIS21-3337
TIS21-3343