### PR TITLE
fix: restrict access to account details

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -13,6 +13,14 @@
           "valueFrom": "/tis/trainee/user-management/sentry/dsn"
         },
         {
+          "name": "PROFILE_HOST",
+          "valueFrom": "tis-${environment}-lb-url"
+        },
+        {
+          "name": "PROFILE_PORT",
+          "valueFrom": "tis-tis-profile-${environment}-port"
+        },
+        {
           "name": "REQUEST_QUEUE_URL",
           "valueFrom": "/tis/trainee/sync/${environment}/queue-url"
         }

--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -61,6 +61,19 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.codeartifact-username }}
+          aws-secret-access-key: ${{ secrets.codeartifact-password }}
+          aws-region: eu-west-1
+
+      - name: Add CodeArtifact env var
+        run: |
+          CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+
       - name: Build with Gradle
         run: ./gradlew assemble
 
@@ -92,6 +105,19 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.codeartifact-username }}
+          aws-secret-access-key: ${{ secrets.codeartifact-password }}
+          aws-region: eu-west-1
+
+      - name: Add CodeArtifact env var
+        run: |
+          CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+
       - name: Run Gradle checks
         run: ./gradlew check -x test
 
@@ -122,6 +148,19 @@ jobs:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.codeartifact-username }}
+          aws-secret-access-key: ${{ secrets.codeartifact-password }}
+          aws-region: eu-west-1
+
+      - name: Add CodeArtifact env var
+        run: |
+          CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: Run Gradle tests
         run: ./gradlew test
@@ -204,6 +243,19 @@ jobs:
         with:
           name: app-jar
           path: build/libs
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.codeartifact-username }}
+          aws-secret-access-key: ${{ secrets.codeartifact-password }}
+          aws-region: eu-west-1
+
+      - name: Add CodeArtifact env var
+        run: |
+          CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text --duration-seconds 900`
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -11,3 +11,5 @@ jobs:
     uses: health-education-england/.github/.github/workflows/pr-analysis-gradle.yml@main
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
+      codeartifact-username: ${{ secrets.AWS_MAVEN_USERNAME }}
+      codeartifact-password: ${{ secrets.AWS_MAVEN_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,14 @@ configurations {
 
 repositories {
   mavenCentral()
+
+  maven {
+    url "https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/"
+    credentials {
+      username "aws"
+      password System.env.CODEARTIFACT_AUTH_TOKEN
+    }
+  }
 }
 
 dependencyManagement {
@@ -32,9 +40,13 @@ dependencies {
   // Spring Boot starters
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation "org.springframework.boot:spring-boot-starter-security"
   testImplementation("org.springframework.boot:spring-boot-starter-test") {
     exclude group: "org.junit.vintage", module: "junit-vintage-engine"
   }
+
+  implementation "com.transformuk.hee:tis-security-jwt:5.1.4"
+  implementation "com.transformuk.hee:profile-client:3.1.1"
 
   // Lombok
   compileOnly "org.projectlombok:lombok"

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.1.0"
+version = "0.1.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/api/UserAccountResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/api/UserAccountResource.java
@@ -61,7 +61,6 @@ public class UserAccountResource {
    * @return The user account details.
    */
   @GetMapping("/details/{username}")
-  @PreAuthorize("hasAuthority('trainee-support:view')")
   ResponseEntity<UserAccountDetailsDto> getUserAccountDetails(@PathVariable String username) {
     log.info("Account details requested for user '{}'", username);
     AdminGetUserRequest request = new AdminGetUserRequest();

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/api/UserAccountResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/api/UserAccountResource.java
@@ -28,6 +28,7 @@ import com.amazonaws.services.cognitoidp.model.UserNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -60,6 +61,7 @@ public class UserAccountResource {
    * @return The user account details.
    */
   @GetMapping("/details/{username}")
+  @PreAuthorize("hasAuthority('trainee-support:view')")
   ResponseEntity<UserAccountDetailsDto> getUserAccountDetails(@PathVariable String username) {
     log.info("Account details requested for user '{}'", username);
     AdminGetUserRequest request = new AdminGetUserRequest();

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AuditingConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AuditingConfiguration.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Required by TIS Security
+ * Required by TIS Security.
  */
 @Configuration
 public class AuditingConfiguration {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AuditingConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AuditingConfiguration.java
@@ -19,22 +19,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.usermanagement;
+package uk.nhs.tis.trainee.usermanagement.config;
 
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.PropertySource;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
+import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-@SpringBootApplication
-@PropertySource(
-    {
-        "classpath:/application.yml",
-        "classpath:/config/profileclientapplication.properties"
-    }
-)
-public class TisTraineeUserManagementApplication {
+/**
+ * Required by TIS Security
+ */
+@Configuration
+public class AuditingConfiguration {
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeUserManagementApplication.class);
+  @Bean
+  public AuditEventRepository auditEventRepository() {
+    return new InMemoryAuditEventRepository();
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/SecurityConfig.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/SecurityConfig.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -80,7 +81,10 @@ public class SecurityConfig {
     http
         // we don't need CSRF because our token is invulnerable
         .csrf().disable()
-        .authorizeRequests().anyRequest().authenticated()
+        .authorizeRequests()
+        .antMatchers(HttpMethod.GET, "/api/**").hasAuthority("trainee-support:view")
+        .antMatchers(HttpMethod.POST, "/api/**").hasAuthority("trainee-support:modify")
+        .anyRequest().authenticated()
         .and()
         .exceptionHandling().authenticationEntryPoint(unauthorizedHandler)
         .accessDeniedHandler(accessDeniedHandler)

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/SecurityConfig.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/SecurityConfig.java
@@ -49,6 +49,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
 
+  private static final String API_PATH = "/api/**";
+
   private final JwtAuthenticationEntryPoint unauthorizedHandler;
   private final RestAccessDeniedHandler accessDeniedHandler;
   private final JwtAuthenticationProvider authenticationProvider;
@@ -69,7 +71,7 @@ public class SecurityConfig {
   @Bean
   public JwtAuthenticationTokenFilter authenticationTokenFilterBean() {
     JwtAuthenticationTokenFilter authenticationTokenFilter = new JwtAuthenticationTokenFilter(
-        "/api/**");
+        API_PATH);
     authenticationTokenFilter.setAuthenticationManager(authenticationManager());
     authenticationTokenFilter
         .setAuthenticationSuccessHandler(new JwtAuthenticationSuccessHandler());
@@ -82,8 +84,8 @@ public class SecurityConfig {
         // we don't need CSRF because our token is invulnerable
         .csrf().disable()
         .authorizeRequests()
-        .antMatchers(HttpMethod.GET, "/api/**").hasAuthority("trainee-support:view")
-        .antMatchers(HttpMethod.POST, "/api/**").hasAuthority("trainee-support:modify")
+        .antMatchers(HttpMethod.GET, API_PATH).hasAuthority("trainee-support:view")
+        .antMatchers(HttpMethod.POST, API_PATH).hasAuthority("trainee-support:modify")
         .anyRequest().authenticated()
         .and()
         .exceptionHandling().authenticationEntryPoint(unauthorizedHandler)

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/SecurityConfig.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/SecurityConfig.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.config;
+
+import com.transformuk.hee.tis.profile.client.config.JwtSpringSecurityConfig;
+import com.transformuk.hee.tis.security.JwtAuthenticationEntryPoint;
+import com.transformuk.hee.tis.security.JwtAuthenticationProvider;
+import com.transformuk.hee.tis.security.JwtAuthenticationSuccessHandler;
+import com.transformuk.hee.tis.security.RestAccessDeniedHandler;
+import com.transformuk.hee.tis.security.filter.JwtAuthenticationTokenFilter;
+import java.util.Collections;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableAutoConfiguration
+@Import(JwtSpringSecurityConfig.class)
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+  private final JwtAuthenticationEntryPoint unauthorizedHandler;
+  private final RestAccessDeniedHandler accessDeniedHandler;
+  private final JwtAuthenticationProvider authenticationProvider;
+
+  SecurityConfig(JwtAuthenticationEntryPoint unauthorizedHandler,
+      RestAccessDeniedHandler accessDeniedHandler,
+      JwtAuthenticationProvider authenticationProvider) {
+    this.unauthorizedHandler = unauthorizedHandler;
+    this.accessDeniedHandler = accessDeniedHandler;
+    this.authenticationProvider = authenticationProvider;
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager() {
+    return new ProviderManager(Collections.singletonList(authenticationProvider));
+  }
+
+  @Bean
+  public JwtAuthenticationTokenFilter authenticationTokenFilterBean() {
+    JwtAuthenticationTokenFilter authenticationTokenFilter = new JwtAuthenticationTokenFilter(
+        "/api/**");
+    authenticationTokenFilter.setAuthenticationManager(authenticationManager());
+    authenticationTokenFilter
+        .setAuthenticationSuccessHandler(new JwtAuthenticationSuccessHandler());
+    return authenticationTokenFilter;
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        // we don't need CSRF because our token is invulnerable
+        .csrf().disable()
+        .authorizeRequests().anyRequest().authenticated()
+        .and()
+        .exceptionHandling().authenticationEntryPoint(unauthorizedHandler)
+        .accessDeniedHandler(accessDeniedHandler)
+        .and()
+        // don't create session
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+    // Custom JWT based security filter
+    http.addFilterBefore(authenticationTokenFilterBean(),
+        UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,8 @@ cloud:
   aws:
     region:
       static: ${AWS_REGION}
+
+profile:
+  server:
+    name: ${PROFILE_HOST:localhost}
+    port: ${PROFILE_PORT:8082}


### PR DESCRIPTION
Restrict access to the account details endpoint to only users with the
`trainee-support:view` permission.

TIS21-3335
TIS21-3340