### PR TITLE
feat: add mfa status to user account details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "0.1.1"
+version = "0.2.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/UserAccountDetailsDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/UserAccountDetailsDto.java
@@ -26,5 +26,6 @@ import lombok.Value;
 @Value
 public class UserAccountDetailsDto {
 
+  String mfaStatus;
   String userStatus;
 }


### PR DESCRIPTION
Add the user's MFA status to the user account details endpoint, when no
MFA is set the value should default to `NO_MFA`.

TIS21-3362
TIS21-3364