### PR TITLE
feat: update account email when TIS changes

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -13,6 +13,30 @@
           "valueFrom": "trainee-cognito-pool-id-${environment}-v4"
         },
         {
+          "name": "CONTACT_DETAILS_UPDATED_QUEUE",
+          "valueFrom": "/tis/trainee/user-management/${environment}/queue-url/contact-details/updated"
+        },
+        {
+          "name": "REDIS_HOST",
+          "valueFrom": "/tis/trainee/${environment}/redis/host"
+        },
+        {
+          "name": "REDIS_PASSWORD",
+          "valueFrom": "/tis/trainee/${environment}/redis/password"
+        },
+        {
+          "name": "REDIS_PORT",
+          "valueFrom": "/tis/trainee/${environment}/redis/port"
+        },
+        {
+          "name": "REDIS_SSL",
+          "valueFrom": "/tis/trainee/${environment}/redis/ssl"
+        },
+        {
+          "name": "REDIS_USERNAME",
+          "valueFrom": "/tis/trainee/${environment}/redis/user"
+        },
+        {
           "name": "SENTRY_DSN",
           "valueFrom": "/tis/trainee/user-management/sentry/dsn"
         },

--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ gradlew bootRun
 | AWS_XRAY_DAEMON_ADDRESS       | The AWS XRay daemon host.                               |           |
 | COGNITO_DSP_CONSULTANT_GROUP  | The name of the Cognito user group for DSP consultants. |           |
 | COGNITO_USER_POOL_ID          | The ID of the Cognito user pool to manage.              |           |
+| CONTACT_DETAILS_UPDATED_QUEUE | The ARN of a queue to received contact detail events.   |           |
 | ENVIRONMENT                   | The environment to log events against.                  | local     |
 | PROFILE_HOST                  | The host of TIS-Profile service.                        | localhost |
 | PROFILE_PORT                  | The port number of TIS-Profile service.                 | 8082      |
+| REDIS_HOST                    | Redis server host                                       | localhost |
+| REDIS_PASSWORD                | Login password of the redis server.                     | password  |
+| REDIS_PORT                    | Redis server port.                                      | 6379      |
+| REDIS_SSL                     | Whether to enable SSL support.                          | false     |
+| REDIS_USERNAME                | Login username of the redis server                      | default   |
 | REQUEST_QUEUE_URL             | The URL of sync request queue.                          |           |
 | SENTRY_DSN                    | A Sentry error monitoring Data Source Name.             |           |
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.3.0"
+version = "1.4.0"
 
 configurations {
   compileOnly {
@@ -32,6 +32,7 @@ repositories {
 
 dependencyManagement {
   imports {
+    mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.8")
     mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:2.4.4")
   }
 }
@@ -39,6 +40,7 @@ dependencyManagement {
 dependencies {
   // Spring Boot starters
   implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("org.springframework.boot:spring-boot-starter-web")
   implementation("org.springframework.boot:spring-boot-starter-security")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -65,6 +67,10 @@ dependencies {
   implementation("com.amazonaws:aws-java-sdk-cognitoidp")
   implementation("io.awspring.cloud:spring-cloud-starter-aws-messaging")
   implementation("com.amazonaws:aws-xray-recorder-sdk-spring:2.15.1")
+
+  testImplementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
+  testImplementation("com.playtika.testcontainers:embedded-redis:2.3.6")
+  testImplementation("org.testcontainers:junit-jupiter:1.19.7")
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/CacheConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/CacheConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.config;
+
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheManager.RedisCacheManagerBuilder;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Configuration for caching behaviour.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+
+  private final String prefix;
+  private final Duration ttl;
+
+  /**
+   * Configuration for caching behaviour.
+   *
+   * @param prefix The cache key prefix.
+   * @param ttl    The time-to-live for cached data.
+   */
+  CacheConfiguration(@Value("${application.cache.key-prefix}") String prefix,
+      @Value("${application.cache.time-to-live}") Duration ttl) {
+    this.prefix = prefix;
+    this.ttl = ttl;
+  }
+
+  /**
+   * Create a cache manager with configured TTL and Prefix.
+   *
+   * @param factory The connection factory to use.
+   * @return The built cache manager.
+   */
+  @Bean
+  public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+    RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(ttl)
+        .prefixCacheNameWith(prefix + CacheKeyPrefix.SEPARATOR);
+
+    return RedisCacheManagerBuilder.fromConnectionFactory(factory)
+        .cacheDefaults(configuration)
+        .build();
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/ContactDetailsDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/ContactDetailsDto.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * An event for contact details changes.
+ *
+ * @param traineeId The trainee ID associated with the contact details.
+ * @param email     The email address from the contact details.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ContactDetailsDto(@JsonAlias("id") String traineeId, String email) {
+
+}

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsEvent.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Getter;
+import uk.nhs.tis.trainee.usermanagement.dto.ContactDetailsDto;
+
+/**
+ * An event wrapper for ContactDetails changes.
+ */
+@Getter
+public class ContactDetailsEvent extends RecordEvent {
+
+  private ContactDetailsDto contactDetails;
+
+  @Override
+  protected void unpackData(JsonNode data) {
+    contactDetails = getObjectMapper().convertValue(data, ContactDetailsDto.class);
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListener.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.event;
+
+import static io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS;
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.nhs.tis.trainee.usermanagement.dto.ContactDetailsDto;
+import uk.nhs.tis.trainee.usermanagement.service.UserAccountService;
+
+@Slf4j
+@Component
+public class ContactDetailsListener {
+
+  private final UserAccountService service;
+
+  public ContactDetailsListener(UserAccountService service) {
+    this.service = service;
+  }
+
+  /**
+   * Handle contact details being updated.
+   *
+   * @param event The contact details update event.
+   */
+  @SqsListener(
+      value = "${application.aws.sqs.contact-details.updated}", deletionPolicy = ON_SUCCESS)
+  public void handleContactDetailsUpdate(ContactDetailsEvent event) {
+    log.info("Received contact details update event '{}'.", event.getContactDetails());
+
+    ContactDetailsDto dto = event.getContactDetails();
+    String traineeId = dto.traineeId();
+    Set<String> userAccountIds = service.getUserAccountIds(traineeId);
+
+    switch (userAccountIds.size()) {
+      case 0 -> log.info("No account exists for trainee {}, skipping username update.", traineeId);
+      case 1 -> {
+        String accountId = userAccountIds.iterator().next();
+        service.updateEmail(accountId, dto.email());
+      }
+      default -> {
+        String message = String.format("%s accounts found for trainee %s, unable to update email.",
+            userAccountIds.size(), traineeId);
+        throw new IllegalArgumentException(message);
+      }
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/event/RecordEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/event/RecordEvent.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.event;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import lombok.Getter;
+
+/**
+ * An abstract representation of a record event.
+ */
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class RecordEvent {
+
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+      .findAndAddModules()
+      .build();
+
+  /**
+   * Unpack the record node of the event JSON.
+   *
+   * @param recordNode The node to unpack.
+   */
+  @JsonProperty("record")
+  private void unpackRecord(JsonNode recordNode) {
+    unpackData(recordNode.get("data"));
+  }
+
+  /**
+   * Unpack the data node of the event JSON.
+   *
+   * @param dataNode The data node to unpack.
+   */
+  protected abstract void unpackData(JsonNode dataNode);
+
+  /**
+   * Get a configured object mapper to use for object conversion.
+   *
+   * @return The configured object mapper.
+   */
+  protected ObjectMapper getObjectMapper() {
+    return OBJECT_MAPPER;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,13 +13,27 @@ application:
       user-pool-id: ${COGNITO_USER_POOL_ID}
       dsp-consultant-group: ${COGNITO_DSP_CONSULTANT_GROUP}
     sqs:
+      contact-details:
+        updated: ${CONTACT_DETAILS_UPDATED_QUEUE:}
       request: ${REQUEST_QUEUE_URL:}
   environment: ${ENVIRONMENT:local}
+  cache:
+    key-prefix: UserManagement
+    time-to-live: PT24H
 
 cloud:
   aws:
     region:
       static: ${AWS_REGION}
+
+spring:
+  redis:
+    host: ${REDIS_HOST:localhost}
+    port: ${REDIS_PORT:6379}
+    ssl:
+      enabled: ${REDIS_SSL:false}
+    username: ${REDIS_USERNAME:default}
+    password: ${REDIS_PASSWORD:password}
 
 profile:
   server:

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/config/CacheConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/config/CacheConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.config;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+class CacheConfigurationTest {
+
+  private CacheConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    this.configuration = new CacheConfiguration("CachePrefix", Duration.ofMinutes(5));
+  }
+
+  @Test
+  void cacheManager() {
+    RedisCacheManager cacheManager = configuration.cacheManager(new LettuceConnectionFactory());
+
+    assertThat("Unexpected cache manager.", cacheManager, notNullValue());
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListenerTest.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.event;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.tis.trainee.usermanagement.service.UserAccountService;
+
+class ContactDetailsListenerTest {
+
+  private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String EMAIL = "unit.test@example.com";
+
+  private ContactDetailsListener listener;
+  private UserAccountService service;
+
+  private ObjectMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(UserAccountService.class);
+    listener = new ContactDetailsListener(service);
+    mapper = JsonMapper.builder()
+        .findAndAddModules()
+        .build();
+  }
+
+  @Test
+  void shouldNotUpdateUsernameWhenNoAccountFoundForUpdate() throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "data": {
+              "id": "%s",
+              "email": "%s"
+            }
+          }
+        }""".formatted(TRAINEE_ID, EMAIL);
+    ContactDetailsEvent event = mapper.readValue(eventJson, ContactDetailsEvent.class);
+
+    when(service.getUserAccountIds(TRAINEE_ID)).thenReturn(Set.of());
+
+    listener.handleContactDetailsUpdate(event);
+
+    verify(service, never()).updateEmail(any(), any());
+  }
+
+  @Test
+  void shouldThrowExceptionWhenMultipleAccountFoundForUpdate() throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "data": {
+              "id": "%s",
+              "email": "%s"
+            }
+          }
+        }""".formatted(TRAINEE_ID, EMAIL);
+    ContactDetailsEvent event = mapper.readValue(eventJson, ContactDetailsEvent.class);
+
+    when(service.getUserAccountIds(TRAINEE_ID)).thenReturn(Set.of(ACCOUNT_ID, "123"));
+
+    assertThrows(IllegalArgumentException.class, () -> listener.handleContactDetailsUpdate(event));
+
+    verify(service, never()).updateEmail(any(), any());
+  }
+
+  @Test
+  void shouldUpdateUsernameWhenSingleAccountFoundForUpdate() throws JsonProcessingException {
+    String eventJson = """
+        {
+          "record": {
+            "data": {
+              "id": "%s",
+              "email": "%s"
+            }
+          }
+        }""".formatted(TRAINEE_ID, EMAIL);
+    ContactDetailsEvent event = mapper.readValue(eventJson, ContactDetailsEvent.class);
+
+    when(service.getUserAccountIds(TRAINEE_ID)).thenReturn(Set.of(ACCOUNT_ID));
+
+    listener.handleContactDetailsUpdate(event);
+
+    verify(service).updateEmail(ACCOUNT_ID, EMAIL);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.service;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
+import com.amazonaws.services.cognitoidp.model.AttributeType;
+import com.amazonaws.services.cognitoidp.model.ListUsersResult;
+import com.amazonaws.services.cognitoidp.model.UserType;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest(properties = {"embedded.containers.enabled=true", "embedded.redis.enabled=true"})
+@ActiveProfiles({"redis", "test"})
+@Testcontainers(disabledWithoutDocker = true)
+@ExtendWith(MockitoExtension.class)
+class UserAccountServiceIntegrationTest {
+
+  private static final String TRAINEE_ID = "40";
+  private static final String USER_ID = UUID.randomUUID().toString();
+
+  private static final String ATTRIBUTE_TRAINEE_ID = "custom:tisId";
+  private static final String ATTRIBUTE_USER_ID = "sub";
+
+  @MockBean
+  private AWSCognitoIdentityProvider cognitoIdp;
+
+  @Autowired
+  UserAccountService service;
+
+  @Autowired
+  CacheManager cacheManager;
+
+  private Cache userIdCache;
+
+  @BeforeEach
+  void setUp() {
+    userIdCache = cacheManager.getCache("UserId");
+    assert userIdCache != null;
+    userIdCache.clear();
+  }
+
+  @Test
+  void shouldBuildUserAccountIdCacheWhenPersonNotInCache() {
+    UserType user = new UserType().withAttributes(
+        new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID),
+        new AttributeType().withName(ATTRIBUTE_USER_ID).withValue(USER_ID)
+    );
+
+    ListUsersResult result = new ListUsersResult();
+    result.setUsers(List.of(user));
+
+    when(cognitoIdp.listUsers(any())).thenReturn(result);
+
+    Set<String> returnedUserIds = service.getUserAccountIds(TRAINEE_ID);
+
+    assertThat("Unexpected user IDs count.", returnedUserIds.size(), is(1));
+    assertThat("Unexpected user IDs.", returnedUserIds, hasItem(USER_ID));
+
+    Set<String> cachedUserIds = userIdCache.get(TRAINEE_ID, Set.class);
+    assertThat("Unexpected user IDs.", cachedUserIds, notNullValue());
+    assertThat("Unexpected user IDs count.", cachedUserIds.size(), is(1));
+    assertThat("Unexpected user IDs.", cachedUserIds, hasItem(USER_ID));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenPersonNotFoundAfterBuildingCache() {
+    UserType user = new UserType().withAttributes(
+        new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID),
+        new AttributeType().withName(ATTRIBUTE_USER_ID).withValue(USER_ID)
+    );
+
+    ListUsersResult result = new ListUsersResult();
+    result.setUsers(List.of(user));
+
+    when(cognitoIdp.listUsers(any())).thenReturn(result);
+
+    Set<String> returnedUserIds = service.getUserAccountIds("notFound");
+
+    assertThat("Unexpected user IDs count.", returnedUserIds.size(), is(0));
+  }
+
+  @Test
+  void shouldReturnCachedUserAccountIdWhenPersonInCache() {
+    userIdCache.put(TRAINEE_ID, Set.of(USER_ID));
+
+    Set<String> returnedUserIds = service.getUserAccountIds(TRAINEE_ID);
+
+    assertThat("Unexpected user IDs count.", returnedUserIds.size(), is(1));
+    assertThat("Unexpected user IDs.", returnedUserIds, hasItem(USER_ID));
+
+    verifyNoInteractions(cognitoIdp);
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
@@ -27,8 +27,11 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
@@ -43,18 +46,28 @@ import com.amazonaws.services.cognitoidp.model.AdminRemoveUserFromGroupRequest;
 import com.amazonaws.services.cognitoidp.model.AdminRemoveUserFromGroupResult;
 import com.amazonaws.services.cognitoidp.model.AdminSetUserMFAPreferenceRequest;
 import com.amazonaws.services.cognitoidp.model.AdminSetUserMFAPreferenceResult;
+import com.amazonaws.services.cognitoidp.model.AdminUpdateUserAttributesRequest;
+import com.amazonaws.services.cognitoidp.model.AttributeType;
 import com.amazonaws.services.cognitoidp.model.AuthEventType;
 import com.amazonaws.services.cognitoidp.model.ChallengeResponseType;
 import com.amazonaws.services.cognitoidp.model.EventContextDataType;
 import com.amazonaws.services.cognitoidp.model.GroupType;
+import com.amazonaws.services.cognitoidp.model.ListUsersRequest;
+import com.amazonaws.services.cognitoidp.model.ListUsersResult;
 import com.amazonaws.services.cognitoidp.model.UserNotFoundException;
 import com.amazonaws.services.cognitoidp.model.UserStatusType;
+import com.amazonaws.services.cognitoidp.model.UserType;
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import uk.nhs.tis.trainee.usermanagement.dto.UserAccountDetailsDto;
 import uk.nhs.tis.trainee.usermanagement.dto.UserLoginDetailsDto;
 
@@ -65,13 +78,27 @@ class UserAccountServiceTest {
   private static final String GROUP_1 = "user-group-one";
   private static final String GROUP_2 = "user-group-two";
 
+  private static final String TRAINEE_ID_1 = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID_2 = UUID.randomUUID().toString();
+  private static final String USER_ID_1 = UUID.randomUUID().toString();
+  private static final String USER_ID_2 = UUID.randomUUID().toString();
+
+  private static final String ATTRIBUTE_TRAINEE_ID = "custom:tisId";
+  private static final String ATTRIBUTE_USER_ID = "sub";
+
   private UserAccountService service;
   private AWSCognitoIdentityProvider cognitoIdp;
+  private Cache cache;
 
   @BeforeEach
   void setUp() {
     cognitoIdp = mock(AWSCognitoIdentityProvider.class);
-    service = new UserAccountService(cognitoIdp, USER_POOL_ID);
+    cache = mock(Cache.class);
+
+    CacheManager cacheManager = mock(CacheManager.class);
+    when(cacheManager.getCache("UserId")).thenReturn(cache);
+
+    service = new UserAccountService(cognitoIdp, USER_POOL_ID, cacheManager);
 
     // Initialize groups as an empty list instead of null, which reflects default AWS API behaviour.
     AdminListGroupsForUserResult mockGroupResult = new AdminListGroupsForUserResult();
@@ -229,6 +256,63 @@ class UserAccountServiceTest {
   }
 
   @Test
+  void shouldThrowExceptionUpdatingEmailWhenEmailBelongsToAnotherAccount() {
+    String newEmail = "new.email@example.com";
+
+    AdminGetUserResult getUserResult = new AdminGetUserResult();
+    getUserResult.setUsername(USER_ID_2);
+
+    when(cognitoIdp.adminGetUser(any())).thenReturn(getUserResult);
+
+    assertThrows(IllegalArgumentException.class, () -> service.updateEmail(USER_ID_1, newEmail));
+
+    verify(cognitoIdp, never()).adminUpdateUserAttributes(any());
+  }
+
+  @Test
+  void shouldNotUpdateEmailWhenTheEmailHasNotChanged() {
+    String newEmail = "new.email@example.com";
+
+    AdminGetUserResult getUserResult = new AdminGetUserResult();
+    getUserResult.setUsername(USER_ID_1);
+
+    when(cognitoIdp.adminGetUser(any())).thenReturn(getUserResult);
+
+    service.updateEmail(USER_ID_1, newEmail);
+
+    verify(cognitoIdp, never()).adminUpdateUserAttributes(any());
+  }
+
+  @Test
+  void shouldUpdateEmailWhenNewEmailNotExistsInUserPool() {
+    String newEmail = "new.email@example.com";
+
+    when(cognitoIdp.adminGetUser(any())).thenThrow(UserNotFoundException.class);
+
+    service.updateEmail(USER_ID_1, newEmail);
+
+    ArgumentCaptor<AdminUpdateUserAttributesRequest> requestCaptor = ArgumentCaptor.forClass(
+        AdminUpdateUserAttributesRequest.class);
+    verify(cognitoIdp).adminUpdateUserAttributes(requestCaptor.capture());
+
+    AdminUpdateUserAttributesRequest request = requestCaptor.getValue();
+
+    assertThat("Unexpected user pool.", request.getUserPoolId(), is(USER_POOL_ID));
+    assertThat("Unexpected user ID.", request.getUsername(), is(USER_ID_1));
+
+    List<AttributeType> userAttributes = request.getUserAttributes();
+    assertThat("Unexpected attribute count.", userAttributes.size(), is(2));
+
+    AttributeType userAttribute = userAttributes.get(0);
+    assertThat("Unexpected attribute name.", userAttribute.getName(), is("email"));
+    assertThat("Unexpected attribute value.", userAttribute.getValue(), is(newEmail));
+
+    userAttribute = userAttributes.get(1);
+    assertThat("Unexpected attribute name.", userAttribute.getName(), is("email_verified"));
+    assertThat("Unexpected attribute value.", userAttribute.getValue(), is("true"));
+  }
+
+  @Test
   void shouldResetSmsMfa() {
     ArgumentCaptor<AdminSetUserMFAPreferenceRequest> requestCaptor = ArgumentCaptor.forClass(
         AdminSetUserMFAPreferenceRequest.class);
@@ -381,5 +465,126 @@ class UserAccountServiceTest {
     assertThat("Unexpected login device.", loginTwo.getDevice(), is("DEVICE_2"));
     assertThat("Unexpected login challenge.", loginTwo.getChallenges(),
         is("Password:Failure"));
+  }
+
+  @Test
+  void shouldRequestUserAccountIdsFromGivenUserPoolWhenGettingUserAccountIds() {
+    ListUsersResult result = new ListUsersResult();
+    result.setUsers(List.of());
+
+    ArgumentCaptor<ListUsersRequest> requestCaptor = ArgumentCaptor.forClass(
+        ListUsersRequest.class);
+    when(cognitoIdp.listUsers(requestCaptor.capture())).thenReturn(result);
+
+    service.getUserAccountIds(TRAINEE_ID_1);
+
+    ListUsersRequest request = requestCaptor.getValue();
+    assertThat("Unexpected request user pool.", request.getUserPoolId(), is(USER_POOL_ID));
+  }
+
+  @Test
+  void shouldCacheAllUserAccountIdsWhenGettingUserAccountIds() {
+    UserType user1 = new UserType().withAttributes(
+        new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID_1),
+        new AttributeType().withName(ATTRIBUTE_USER_ID).withValue(USER_ID_1)
+    );
+    UserType user2 = new UserType().withAttributes(
+        new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID_2),
+        new AttributeType().withName(ATTRIBUTE_USER_ID).withValue(USER_ID_2)
+    );
+
+    ListUsersResult result = new ListUsersResult();
+    result.setUsers(List.of(user1, user2));
+
+    when(cognitoIdp.listUsers(any(ListUsersRequest.class))).thenReturn(result);
+
+    when(cache.get(any())).thenReturn(null);
+
+    service.getUserAccountIds(TRAINEE_ID_1);
+
+    verify(cache).put(TRAINEE_ID_1, Set.of(USER_ID_1));
+    verify(cache).put(TRAINEE_ID_2, Set.of(USER_ID_2));
+  }
+
+  @Test
+  void shouldPaginateThroughAllUserAccountIdsWhenGettingUserAccountIds() {
+    ListUsersResult result1 = new ListUsersResult();
+    result1.setUsers(List.of(new UserType().withAttributes(
+        new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID_1),
+        new AttributeType().withName(ATTRIBUTE_USER_ID).withValue(USER_ID_1)
+    )));
+    result1.setPaginationToken("tokenforpage2");
+
+    ListUsersResult result2 = new ListUsersResult();
+    result2.setUsers(List.of(new UserType().withAttributes(
+        new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID_2),
+        new AttributeType().withName(ATTRIBUTE_USER_ID).withValue(USER_ID_2)
+    )));
+
+    ArgumentCaptor<ListUsersRequest> requestCaptor = ArgumentCaptor.forClass(
+        ListUsersRequest.class);
+    when(cognitoIdp.listUsers(requestCaptor.capture())).thenReturn(result1, result2);
+
+    when(cache.get(any())).thenReturn(null);
+
+    service.getUserAccountIds(TRAINEE_ID_1);
+
+    verify(cache).put(TRAINEE_ID_1, Set.of(USER_ID_1));
+    verify(cache).put(TRAINEE_ID_2, Set.of(USER_ID_2));
+
+    List<ListUsersRequest> requests = requestCaptor.getAllValues();
+    assertThat("Unexpected request count.", requests.size(), is(2));
+    ListUsersRequest request1 = requests.get(0);
+    assertThat("Unexpected pagination token.", request1.getPaginationToken(), nullValue());
+    ListUsersRequest request2 = requests.get(1);
+    assertThat("Unexpected pagination token.", request2.getPaginationToken(), is("tokenforpage2"));
+  }
+
+  @Test
+  void shouldCacheDuplicateUserAccountIdsWhenGettingUserAccountIds() {
+    UserType user = new UserType().withAttributes(
+        new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID_1),
+        new AttributeType().withName(ATTRIBUTE_USER_ID).withValue(USER_ID_2)
+    );
+
+    ListUsersResult result = new ListUsersResult();
+    result.setUsers(List.of(user));
+
+    when(cognitoIdp.listUsers(any(ListUsersRequest.class))).thenReturn(result);
+
+    when(cache.get(TRAINEE_ID_1, Set.class)).thenReturn(new HashSet<>(Set.of(USER_ID_1)));
+
+    service.getUserAccountIds(TRAINEE_ID_1);
+
+    verify(cache).put(TRAINEE_ID_1, Set.of(USER_ID_1, USER_ID_2));
+  }
+
+  @Test
+  void shouldGetUserAccountIdsFromCache() {
+    ListUsersResult result = new ListUsersResult();
+    result.setUsers(List.of());
+
+    when(cognitoIdp.listUsers(any(ListUsersRequest.class))).thenReturn(result);
+
+    when(cache.get(TRAINEE_ID_1, Set.class)).thenReturn(Set.of(USER_ID_1, USER_ID_2));
+
+    Set<String> userAccountIds = service.getUserAccountIds(TRAINEE_ID_1);
+
+    assertThat("Unexpected user IDs count.", userAccountIds.size(), is(2));
+    assertThat("Unexpected user IDs.", userAccountIds, hasItems(USER_ID_1, USER_ID_2));
+  }
+
+  @Test
+  void shouldGetEmptyUserAccountIdsWhenAccountNotFoundAfterBuildingCache() {
+    ListUsersResult result = new ListUsersResult();
+    result.setUsers(List.of());
+
+    when(cognitoIdp.listUsers(any(ListUsersRequest.class))).thenReturn(result);
+
+    when(cache.get(TRAINEE_ID_1, Set.class)).thenReturn(null);
+
+    Set<String> userAccountIds = service.getUserAccountIds(TRAINEE_ID_1);
+
+    assertThat("Unexpected user IDs count.", userAccountIds.size(), is(0));
   }
 }

--- a/src/test/resources/application-redis.yml
+++ b/src/test/resources/application-redis.yml
@@ -1,0 +1,6 @@
+spring:
+  redis:
+    host: ${embedded.redis.host}
+    port: ${embedded.redis.port}
+    user: ${embedded.redis.user}
+    password: ${embedded.redis.password}

--- a/src/test/resources/bootstrap.properties
+++ b/src/test/resources/bootstrap.properties
@@ -1,0 +1,2 @@
+embedded.containers.enabled=false
+embedded.redis.enabled=false


### PR DESCRIPTION
Update the email address associated with a user account when the TIS contact details are changed.
The email should only be updated if it is not in use by any other user.

Exceptions should be throw in two cases
 - Where multiple accounts exist for a given PersonId
 - Where the new email address is already in use

Cache the users retrieved from cognito as the lookup is costly.

TIS21-5907
TIS21-5940