### PR TITLE
fix: SQS message conversion error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.4.0"
+version = "1.4.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AmazonSqsConfig.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AmazonSqsConfig.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.config;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+
+@Configuration
+public class AmazonSqsConfig {
+
+  /**
+   * Create a default {@link AmazonSQSAsync} bean.
+   *
+   * @return The created bean.
+   */
+  @Bean
+  @Primary
+  public AmazonSQSAsync amazonSqsAsync() {
+    return AmazonSQSAsyncClientBuilder.defaultClient();
+  }
+
+  /**
+   * Create a default {@link QueueMessagingTemplate} bean.
+   *
+   * @return The created bean.
+   */
+  @Bean
+  public QueueMessagingTemplate queueMessagingTemplate() {
+    return new QueueMessagingTemplate(amazonSqsAsync());
+  }
+
+  /**
+   * Create a message converter bean with an object mapper.
+   *
+   * @param objectMapper The object mapper to set.
+   * @return The created message converter.
+   */
+  @Bean
+  public MessageConverter messageConverter(ObjectMapper objectMapper) {
+    var converter = new MappingJackson2MessageConverter();
+    converter.setObjectMapper(objectMapper);
+    return converter;
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/event/RecordEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/event/RecordEvent.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.tis.trainee.usermanagement.event;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,7 +31,6 @@ import lombok.Getter;
  * An abstract representation of a record event.
  */
 @Getter
-@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class RecordEvent {
 
   private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()


### PR DESCRIPTION
The SQS listener for contact details is failing to convert the message from a String in to an event POJO because the default string converter is being used.

Add additional SQS config so that the listener uses a Jackson converter/mapper instead.

TIS21-5907
TIS21-5940