### PR TITLE
fix: redis connection timeout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.4.1"
+version = "1.4.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,7 @@ spring:
       enabled: ${REDIS_SSL:false}
     username: ${REDIS_USERNAME:default}
     password: ${REDIS_PASSWORD:password}
+    timeout: 60000
 
 profile:
   server:


### PR DESCRIPTION
The redis connection is timing out when connecting within AWS. Up the timeout the `60000`, which is the same value as the sync service uses.

TIS21-5907
TIS21-5940