### PR TITLE
chore: update redis params

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -18,23 +18,23 @@
         },
         {
           "name": "REDIS_HOST",
-          "valueFrom": "/tis/trainee/${environment}/redis/host"
+          "valueFrom": "/tis/core/${environment}/redis/host"
         },
         {
           "name": "REDIS_PASSWORD",
-          "valueFrom": "/tis/trainee/${environment}/redis/password"
+          "valueFrom": "/tis/core/${environment}/redis/password"
         },
         {
           "name": "REDIS_PORT",
-          "valueFrom": "/tis/trainee/${environment}/redis/port"
+          "valueFrom": "/tis/core/${environment}/redis/port"
         },
         {
           "name": "REDIS_SSL",
-          "valueFrom": "/tis/trainee/${environment}/redis/ssl"
+          "valueFrom": "/tis/core/${environment}/redis/ssl"
         },
         {
           "name": "REDIS_USERNAME",
-          "valueFrom": "/tis/trainee/${environment}/redis/user"
+          "valueFrom": "/tis/core/${environment}/redis/user"
         },
         {
           "name": "SENTRY_DSN",


### PR DESCRIPTION
The service is deployed to TIS VPCs with no access to the trainee redis cache. Update the redis params to use the TIS Core redis cache instead.

TIS21-5907
TIS21-5940