### PR TITLE
fix: back off when too many cognito requests made

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.4.4"
+version = "1.4.5"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
@@ -40,6 +40,7 @@ import com.amazonaws.services.cognitoidp.model.ListUsersRequest;
 import com.amazonaws.services.cognitoidp.model.ListUsersResult;
 import com.amazonaws.services.cognitoidp.model.SMSMfaSettingsType;
 import com.amazonaws.services.cognitoidp.model.SoftwareTokenMfaSettingsType;
+import com.amazonaws.services.cognitoidp.model.TooManyRequestsException;
 import com.amazonaws.services.cognitoidp.model.UserNotFoundException;
 import com.amazonaws.services.cognitoidp.model.UserType;
 import com.amazonaws.xray.spring.aop.XRayEnabled;
@@ -329,29 +330,48 @@ public class UserAccountService {
       request.setUserPoolId(userPoolId);
       request.setPaginationToken(paginationToken);
 
-      ListUsersResult result = cognitoIdp.listUsers(request);
-      result.getUsers().stream()
-          .map(UserType::getAttributes)
-          .map(attributes -> attributes.stream()
-              .collect(Collectors.toMap(AttributeType::getName, AttributeType::getValue))
-          )
-          .forEach(attr -> {
-            String tisId = attr.get("custom:tisId");
-            Set<String> ids = cache.get(tisId, Set.class);
-
-            if (ids == null) {
-              ids = new HashSet<>();
-            }
-
-            ids.add(attr.get("sub"));
-            cache.put(tisId, ids);
-          });
-
-      paginationToken = result.getPaginationToken();
+      try {
+        ListUsersResult result = cognitoIdp.listUsers(request);
+        cacheUserAccountIds(result);
+        paginationToken = result.getPaginationToken();
+      } catch (TooManyRequestsException tmre) {
+        try {
+          // Cognito requests are limited to 5 per second.
+          log.warn("Cognito requests have exceed the limit.", tmre);
+          Thread.sleep(200);
+        } catch (InterruptedException ie) {
+          log.warn("Unabled to sleep thread.", ie);
+        }
+      }
     } while (paginationToken != null);
 
     cacheTimer.stop();
     log.info("Total time taken to cache all user accounts was: {}s",
         cacheTimer.getTotalTimeSeconds());
+  }
+
+  /**
+   * Cache the user accounts ids for the given result.
+   *
+   * @param result The result of a ListUsersRequest.
+   */
+  private void cacheUserAccountIds(ListUsersResult result) {
+
+    result.getUsers().stream()
+        .map(UserType::getAttributes)
+        .map(attributes -> attributes.stream()
+            .collect(Collectors.toMap(AttributeType::getName, AttributeType::getValue))
+        )
+        .forEach(attr -> {
+          String tisId = attr.get("custom:tisId");
+          Set<String> ids = cache.get(tisId, Set.class);
+
+          if (ids == null) {
+            ids = new HashSet<>();
+          }
+
+          ids.add(attr.get("sub"));
+          cache.put(tisId, ids);
+        });
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
@@ -340,7 +340,8 @@ public class UserAccountService {
           log.warn("Cognito requests have exceed the limit.", tmre);
           Thread.sleep(200);
         } catch (InterruptedException ie) {
-          log.warn("Unabled to sleep thread.", ie);
+          log.warn("Unable to sleep thread.", ie);
+          Thread.currentThread().interrupt();
         }
       }
     } while (paginationToken != null);


### PR DESCRIPTION
Cognito requests are limited to five per second, back off once the limit is reached and sleep the thread.

TIS21-5907