### PR TITLE
fix: repeated caching of missing users

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.4.5"
+version = "1.4.6"
 
 configurations {
   compileOnly {

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
@@ -33,6 +33,7 @@ import com.amazonaws.services.cognitoidp.AWSCognitoIdentityProvider;
 import com.amazonaws.services.cognitoidp.model.AttributeType;
 import com.amazonaws.services.cognitoidp.model.ListUsersResult;
 import com.amazonaws.services.cognitoidp.model.UserType;
+import io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -45,6 +46,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -52,6 +55,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ActiveProfiles({"redis", "test"})
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(MockitoExtension.class)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 class UserAccountServiceIntegrationTest {
 
   private static final String TRAINEE_ID = "40";
@@ -62,6 +66,9 @@ class UserAccountServiceIntegrationTest {
 
   @MockBean
   private AWSCognitoIdentityProvider cognitoIdp;
+
+  @MockBean
+  private SimpleMessageListenerContainer listenerContainer;
 
   @Autowired
   UserAccountService service;


### PR DESCRIPTION
When a trainee ID is not found in the existing cache, a lookup is performed on the Cognito user pool and all users are re-cached. As there can be a large number of person records without Cognito accounts it can lead to attempts to constant re-cache the user pool over and over.

The queue listener should be disabled during caching to ensure that no overlapping cache calls can be made from parallel messages.

A fifteen minute window should be added after each full cache operation, during which no re-caching will occur. This will help reduce demand on the Cognito API when processing large numbers of contact detail changes. The fifteen minutes is fairly arbitrary and may need tweaking, until a longer term solution can be put in place.

TIS21-5907
TIS21-5958