### PR TITLE
fix: remove queue pausing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.4.6"
+version = "1.4.7"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
For reasons unknown, the act of auto-wiring the
`SimpleMessageListenerContainer` breaks the message conversion configuration.
Revert that functionality, leaving just the 15 minute block on re-caching.

TIS21-5907