### PR TITLE
feat: publish event when user email changed

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -55,6 +55,10 @@
         {
           "name": "COGNITO_DSP_CONSULTANT_GROUP",
           "valueFrom": "/tis/trainee/cognito/${environment}/dsp-consultant-group"
+        },
+        {
+          "name": "USER_ACCOUNT_UPDATE_EVENT_TOPIC",
+          "valueFrom": "/tis/trainee/${environment}/topic-arn/update-user-account-event"
         }
       ],
       "logConfiguration": {

--- a/README.md
+++ b/README.md
@@ -19,23 +19,24 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name                          | Description                                             | Default   |
-|-------------------------------|---------------------------------------------------------|-----------|
-| AWS_REGION                    | The AWS region to use.                                  |           |
-| AWS_XRAY_DAEMON_ADDRESS       | The AWS XRay daemon host.                               |           |
-| COGNITO_DSP_CONSULTANT_GROUP  | The name of the Cognito user group for DSP consultants. |           |
-| COGNITO_USER_POOL_ID          | The ID of the Cognito user pool to manage.              |           |
-| CONTACT_DETAILS_UPDATED_QUEUE | The ARN of a queue to received contact detail events.   |           |
-| ENVIRONMENT                   | The environment to log events against.                  | local     |
-| PROFILE_HOST                  | The host of TIS-Profile service.                        | localhost |
-| PROFILE_PORT                  | The port number of TIS-Profile service.                 | 8082      |
-| REDIS_HOST                    | Redis server host                                       | localhost |
-| REDIS_PASSWORD                | Login password of the redis server.                     | password  |
-| REDIS_PORT                    | Redis server port.                                      | 6379      |
-| REDIS_SSL                     | Whether to enable SSL support.                          | false     |
-| REDIS_USERNAME                | Login username of the redis server                      | default   |
-| REQUEST_QUEUE_URL             | The URL of sync request queue.                          |           |
-| SENTRY_DSN                    | A Sentry error monitoring Data Source Name.             |           |
+| Name                            | Description                                             | Default   |
+|---------------------------------|---------------------------------------------------------|-----------|
+| AWS_REGION                      | The AWS region to use.                                  |           |
+| AWS_XRAY_DAEMON_ADDRESS         | The AWS XRay daemon host.                               |           |
+| COGNITO_DSP_CONSULTANT_GROUP    | The name of the Cognito user group for DSP consultants. |           |
+| COGNITO_USER_POOL_ID            | The ID of the Cognito user pool to manage.              |           |
+| CONTACT_DETAILS_UPDATED_QUEUE   | The ARN of a queue to received contact detail events.   |           |
+| ENVIRONMENT                     | The environment to log events against.                  | local     |
+| PROFILE_HOST                    | The host of TIS-Profile service.                        | localhost |
+| PROFILE_PORT                    | The port number of TIS-Profile service.                 | 8082      |
+| REDIS_HOST                      | Redis server host                                       | localhost |
+| REDIS_PASSWORD                  | Login password of the redis server.                     | password  |
+| REDIS_PORT                      | Redis server port.                                      | 6379      |
+| REDIS_SSL                       | Whether to enable SSL support.                          | false     |
+| REDIS_USERNAME                  | Login username of the redis server                      | default   |
+| REQUEST_QUEUE_URL               | The URL of sync request queue.                          |           |
+| SENTRY_DSN                      | A Sentry error monitoring Data Source Name.             |           |
+| USER_ACCOUNT_UPDATE_EVENT_TOPIC | The topic ARN to publish user account update events to. |           |
 
 #### Usage Examples
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.4.7"
+version = "1.5.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AmazonMessagingConfig.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AmazonMessagingConfig.java
@@ -21,9 +21,12 @@
 
 package uk.nhs.tis.trainee.usermanagement.config;
 
+import com.amazonaws.services.sns.AmazonSNSAsync;
+import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.messaging.core.NotificationMessagingTemplate;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,7 +35,28 @@ import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConverter;
 
 @Configuration
-public class AmazonSqsConfig {
+public class AmazonMessagingConfig {
+
+  /**
+   * Create a default {@link AmazonSNSAsync} bean.
+   *
+   * @return The created bean.
+   */
+  @Bean
+  @Primary
+  public AmazonSNSAsync amazonSnsAsync() {
+    return AmazonSNSAsyncClientBuilder.defaultClient();
+  }
+
+  /**
+   * Create a default {@link NotificationMessagingTemplate} bean.
+   *
+   * @return The created bean.
+   */
+  @Bean
+  public NotificationMessagingTemplate notificationMessagingTemplate() {
+    return new NotificationMessagingTemplate(amazonSnsAsync());
+  }
 
   /**
    * Create a default {@link AmazonSQSAsync} bean.

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/event/EmailUpdateEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/event/EmailUpdateEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,23 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.usermanagement;
+package uk.nhs.tis.trainee.usermanagement.event;
 
-import io.awspring.cloud.messaging.core.NotificationMessagingTemplate;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
+/**
+ * An event to be published when an account email is updated.
+ *
+ * @param userId        The ID of the user account.
+ * @param previousEmail The previous email used as the username.
+ * @param newEmail      The new email used as the username.
+ */
+public record EmailUpdateEvent(String userId, String previousEmail, String newEmail) {
 
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeUserManagementApplicationTest {
-
-  @MockBean
-  private NotificationMessagingTemplate template;
-
-  @Test
-  void contextLoads() {
-
-  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/event/EmailUpdateEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/event/EmailUpdateEvent.java
@@ -25,9 +25,11 @@ package uk.nhs.tis.trainee.usermanagement.event;
  * An event to be published when an account email is updated.
  *
  * @param userId        The ID of the user account.
+ * @param traineeId     The ID of the trainee.
  * @param previousEmail The previous email used as the username.
  * @param newEmail      The new email used as the username.
  */
-public record EmailUpdateEvent(String userId, String previousEmail, String newEmail) {
+public record EmailUpdateEvent(String userId, String traineeId, String previousEmail,
+                               String newEmail) {
 
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishService.java
@@ -73,13 +73,15 @@ public class EventPublishService {
    * Public an event containing details of a user account email changing.
    *
    * @param userId        The ID of the user account.
+   * @param traineeId     The ID of the trainee.
    * @param previousEmail The original email associated with the account.
    * @param newEmail      The new email associated with the account.
    */
-  public void publishEmailUpdateEvent(String userId, String previousEmail, String newEmail) {
+  public void publishEmailUpdateEvent(String userId, String traineeId, String previousEmail,
+      String newEmail) {
     log.info("Publishing email update event for previous email '{}' and new email '{}'.",
         previousEmail, newEmail);
-    EmailUpdateEvent event = new EmailUpdateEvent(userId, previousEmail, newEmail);
+    EmailUpdateEvent event = new EmailUpdateEvent(userId, traineeId, previousEmail, newEmail);
     notificationMessagingTemplate.convertAndSend(userAccountUpdateTopicArn, event, Map.of(
         NOTIFICATION_SUBJECT_HEADER, "Account Email Updated",
         MESSAGE_GROUP_ID_HEADER, userId,

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishService.java
@@ -21,12 +21,18 @@
 
 package uk.nhs.tis.trainee.usermanagement.service;
 
+import static io.awspring.cloud.messaging.core.TopicMessageChannel.MESSAGE_GROUP_ID_HEADER;
+import static io.awspring.cloud.messaging.core.TopicMessageChannel.NOTIFICATION_SUBJECT_HEADER;
+
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import io.awspring.cloud.messaging.core.NotificationMessagingTemplate;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.tis.trainee.usermanagement.event.DataRequestEvent;
+import uk.nhs.tis.trainee.usermanagement.event.EmailUpdateEvent;
 
 /**
  * A service to publish events to SQS.
@@ -36,13 +42,19 @@ import uk.nhs.tis.trainee.usermanagement.event.DataRequestEvent;
 @XRayEnabled
 public class EventPublishService {
 
-  private final QueueMessagingTemplate messagingTemplate;
+  private final NotificationMessagingTemplate notificationMessagingTemplate;
+  private final QueueMessagingTemplate queueMessagingTemplate;
+  private final String userAccountUpdateTopicArn;
   private final String queueUrl;
 
-  EventPublishService(QueueMessagingTemplate messagingTemplate,
-      @Value("${application.aws.sqs.request}") String queueUrl) {
-    this.messagingTemplate = messagingTemplate;
-    this.queueUrl = queueUrl;
+  EventPublishService(NotificationMessagingTemplate notificationMessagingTemplate,
+      @Value("${application.aws.sns.user-account.update}") String userAccountUpdateTopicArn,
+      QueueMessagingTemplate queueMessagingTemplate,
+      @Value("${application.aws.sqs.request}") String requestQueueUrl) {
+    this.notificationMessagingTemplate = notificationMessagingTemplate;
+    this.userAccountUpdateTopicArn = userAccountUpdateTopicArn;
+    this.queueMessagingTemplate = queueMessagingTemplate;
+    this.queueUrl = requestQueueUrl;
   }
 
   /**
@@ -54,6 +66,24 @@ public class EventPublishService {
     log.info("Sending single profile sync event for trainee id '{}'", traineeTisId);
 
     DataRequestEvent dataRequestEvent = new DataRequestEvent("Person", traineeTisId);
-    messagingTemplate.convertAndSend(queueUrl, dataRequestEvent);
+    queueMessagingTemplate.convertAndSend(queueUrl, dataRequestEvent);
+  }
+
+  /**
+   * Public an event containing details of a user account email changing.
+   *
+   * @param userId        The ID of the user account.
+   * @param previousEmail The original email associated with the account.
+   * @param newEmail      The new email associated with the account.
+   */
+  public void publishEmailUpdateEvent(String userId, String previousEmail, String newEmail) {
+    log.info("Publishing email update event for previous email '{}' and new email '{}'.",
+        previousEmail, newEmail);
+    EmailUpdateEvent event = new EmailUpdateEvent(userId, previousEmail, newEmail);
+    notificationMessagingTemplate.convertAndSend(userAccountUpdateTopicArn, event, Map.of(
+        NOTIFICATION_SUBJECT_HEADER, "Account Email Updated",
+        MESSAGE_GROUP_ID_HEADER, userId,
+        "producer", "tis-trainee-user-management"
+    ));
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
@@ -158,6 +158,10 @@ public class UserAccountService {
           .filter(ua -> ua.getName().equals("email"))
           .map(AttributeType::getValue)
           .findFirst();
+      final Optional<String> traineeId = existingDetails.getUserAttributes().stream()
+          .filter(ua -> ua.getName().equals("custom:tisId"))
+          .map(AttributeType::getValue)
+          .findFirst();
 
       AdminUpdateUserAttributesRequest updateRequest = new AdminUpdateUserAttributesRequest();
       updateRequest.setUserPoolId(userPoolId);
@@ -169,7 +173,8 @@ public class UserAccountService {
       ));
 
       cognitoIdp.adminUpdateUserAttributes(updateRequest);
-      eventPublishService.publishEmailUpdateEvent(userId, existingEmail.orElse(null), newEmail);
+      eventPublishService.publishEmailUpdateEvent(userId, traineeId.orElse(null),
+          existingEmail.orElse(null), newEmail);
       log.info("Successfully updated email to '{}' for user '{}'.", newEmail, userId);
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,9 @@ application:
     cognito:
       user-pool-id: ${COGNITO_USER_POOL_ID}
       dsp-consultant-group: ${COGNITO_DSP_CONSULTANT_GROUP}
+    sns:
+      user-account:
+        update: ${USER_ACCOUNT_UPDATE_EVENT_TOPIC:}
     sqs:
       contact-details:
         updated: ${CONTACT_DETAILS_UPDATED_QUEUE:}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishServiceTest.java
@@ -21,29 +21,40 @@
 
 package uk.nhs.tis.trainee.usermanagement.service;
 
+import static io.awspring.cloud.messaging.core.TopicMessageChannel.MESSAGE_GROUP_ID_HEADER;
+import static io.awspring.cloud.messaging.core.TopicMessageChannel.NOTIFICATION_SUBJECT_HEADER;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.awspring.cloud.messaging.core.NotificationMessagingTemplate;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.tis.trainee.usermanagement.event.DataRequestEvent;
+import uk.nhs.tis.trainee.usermanagement.event.EmailUpdateEvent;
 
 class EventPublishServiceTest {
 
-  private static final String QUEUE_URL = "queue.url";
+  private static final String REQUEST_QUEUE_URL = "request.queue.url";
+  private static final String USER_ACCOUNT_UPDATE_TOPIC = "user-account.update.topic.arn";
   private static final String TRAINEE_ID = "11111";
+  private static final String USER_ID = UUID.randomUUID().toString();
   private EventPublishService eventPublishService;
-  private QueueMessagingTemplate messagingTemplate;
+  private NotificationMessagingTemplate notificationMessagingTemplate;
+  private QueueMessagingTemplate queueMessagingTemplate;
 
   @BeforeEach
   void setUp() {
-    messagingTemplate = mock(QueueMessagingTemplate.class);
-    eventPublishService = new EventPublishService(messagingTemplate, QUEUE_URL);
+    notificationMessagingTemplate = mock(NotificationMessagingTemplate.class);
+    queueMessagingTemplate = mock(QueueMessagingTemplate.class);
+    eventPublishService = new EventPublishService(notificationMessagingTemplate,
+        USER_ACCOUNT_UPDATE_TOPIC, queueMessagingTemplate, REQUEST_QUEUE_URL);
   }
 
   @Test
@@ -53,9 +64,35 @@ class EventPublishServiceTest {
 
     ArgumentCaptor<DataRequestEvent> eventCaptor = ArgumentCaptor.forClass(
         DataRequestEvent.class);
-    verify(messagingTemplate).convertAndSend(eq(QUEUE_URL), eventCaptor.capture());
+    verify(queueMessagingTemplate).convertAndSend(eq(REQUEST_QUEUE_URL), eventCaptor.capture());
 
     assertThat("Unexpected table.", eventCaptor.getValue().getTable(), is("Person"));
     assertThat("Unexpected trainee ID.", eventCaptor.getValue().getId(), is(TRAINEE_ID));
+  }
+
+  @Test
+  void shouldPublishEmailUpdateEvent() {
+    String previousEmail = "previous.email@example.com";
+    String newEmail = "new.email@example.com";
+
+    eventPublishService.publishEmailUpdateEvent(USER_ID, previousEmail, newEmail);
+
+    ArgumentCaptor<EmailUpdateEvent> eventCaptor = ArgumentCaptor.forClass(EmailUpdateEvent.class);
+    ArgumentCaptor<Map<String, Object>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(notificationMessagingTemplate).convertAndSend(eq(USER_ACCOUNT_UPDATE_TOPIC),
+        eventCaptor.capture(), headersCaptor.capture());
+
+    EmailUpdateEvent event = eventCaptor.getValue();
+    assertThat("Unexpected user ID.", event.userId(), is(USER_ID));
+    assertThat("Unexpected previous email.", event.previousEmail(), is(previousEmail));
+    assertThat("Unexpected new email.", event.newEmail(), is(newEmail));
+
+    Map<String, Object> headers = headersCaptor.getValue();
+    assertThat("Unexpected header count.", headers.size(), is(3));
+    assertThat("Unexpected subject.", headers.get(NOTIFICATION_SUBJECT_HEADER),
+        is("Account Email Updated"));
+    assertThat("Unexpected group ID.", headers.get(MESSAGE_GROUP_ID_HEADER),
+        is(USER_ID));
+    assertThat("Unexpected producer.", headers.get("producer"), is("tis-trainee-user-management"));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishServiceTest.java
@@ -75,7 +75,7 @@ class EventPublishServiceTest {
     String previousEmail = "previous.email@example.com";
     String newEmail = "new.email@example.com";
 
-    eventPublishService.publishEmailUpdateEvent(USER_ID, previousEmail, newEmail);
+    eventPublishService.publishEmailUpdateEvent(USER_ID, TRAINEE_ID, previousEmail, newEmail);
 
     ArgumentCaptor<EmailUpdateEvent> eventCaptor = ArgumentCaptor.forClass(EmailUpdateEvent.class);
     ArgumentCaptor<Map<String, Object>> headersCaptor = ArgumentCaptor.forClass(Map.class);
@@ -84,6 +84,7 @@ class EventPublishServiceTest {
 
     EmailUpdateEvent event = eventCaptor.getValue();
     assertThat("Unexpected user ID.", event.userId(), is(USER_ID));
+    assertThat("Unexpected trainee ID.", event.traineeId(), is(TRAINEE_ID));
     assertThat("Unexpected previous email.", event.previousEmail(), is(previousEmail));
     assertThat("Unexpected new email.", event.newEmail(), is(newEmail));
 

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
@@ -68,6 +68,9 @@ class UserAccountServiceIntegrationTest {
   private AWSCognitoIdentityProvider cognitoIdp;
 
   @MockBean
+  private EventPublishService eventPublishService;
+
+  @MockBean
   private SimpleMessageListenerContainer listenerContainer;
 
   @Autowired

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
@@ -88,6 +88,8 @@ class UserAccountServiceTest {
 
   private static final String ATTRIBUTE_TRAINEE_ID = "custom:tisId";
   private static final String ATTRIBUTE_USER_ID = "sub";
+  private static final String ATTRIBUTE_EMAIL = "email";
+  private static final String ATTRIBUTE_EMAIL_VERIFIED = "email_verified";
 
   private UserAccountService service;
   private AWSCognitoIdentityProvider cognitoIdp;
@@ -325,11 +327,11 @@ class UserAccountServiceTest {
     assertThat("Unexpected attribute count.", userAttributes.size(), is(2));
 
     AttributeType userAttribute = userAttributes.get(0);
-    assertThat("Unexpected attribute name.", userAttribute.getName(), is("email"));
+    assertThat("Unexpected attribute name.", userAttribute.getName(), is(ATTRIBUTE_EMAIL));
     assertThat("Unexpected attribute value.", userAttribute.getValue(), is(newEmail));
 
     userAttribute = userAttributes.get(1);
-    assertThat("Unexpected attribute name.", userAttribute.getName(), is("email_verified"));
+    assertThat("Unexpected attribute name.", userAttribute.getName(), is(ATTRIBUTE_EMAIL_VERIFIED));
     assertThat("Unexpected attribute value.", userAttribute.getValue(), is("true"));
   }
 
@@ -343,9 +345,9 @@ class UserAccountServiceTest {
     when(cognitoIdp.adminGetUser(getRequestCaptor.capture()))
         .thenThrow(UserNotFoundException.class)
         .thenReturn(new AdminGetUserResult()
-            .withUserAttributes(new AttributeType()
-                .withName("email")
-                .withValue(previousEmail)
+            .withUserAttributes(
+                new AttributeType().withName(ATTRIBUTE_EMAIL).withValue(previousEmail),
+                new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID_1)
             )
         );
 
@@ -357,7 +359,8 @@ class UserAccountServiceTest {
     AdminGetUserRequest getRequest = getRequests.get(1);
     assertThat("Unexpected username.", getRequest.getUsername(), is(USER_ID_1));
 
-    verify(eventPublishService).publishEmailUpdateEvent(USER_ID_1, previousEmail, newEmail);
+    verify(eventPublishService).publishEmailUpdateEvent(USER_ID_1, TRAINEE_ID_1, previousEmail,
+        newEmail);
   }
 
   @Test

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
@@ -40,6 +40,7 @@ import com.amazonaws.services.cognitoidp.model.AdminAddUserToGroupRequest;
 import com.amazonaws.services.cognitoidp.model.AdminAddUserToGroupResult;
 import com.amazonaws.services.cognitoidp.model.AdminDeleteUserRequest;
 import com.amazonaws.services.cognitoidp.model.AdminDeleteUserResult;
+import com.amazonaws.services.cognitoidp.model.AdminGetUserRequest;
 import com.amazonaws.services.cognitoidp.model.AdminGetUserResult;
 import com.amazonaws.services.cognitoidp.model.AdminListGroupsForUserResult;
 import com.amazonaws.services.cognitoidp.model.AdminListUserAuthEventsResult;
@@ -91,6 +92,7 @@ class UserAccountServiceTest {
   private UserAccountService service;
   private AWSCognitoIdentityProvider cognitoIdp;
   private Cache cache;
+  private EventPublishService eventPublishService;
 
   @BeforeEach
   void setUp() {
@@ -100,7 +102,9 @@ class UserAccountServiceTest {
     CacheManager cacheManager = mock(CacheManager.class);
     when(cacheManager.getCache("UserId")).thenReturn(cache);
 
-    service = new UserAccountService(cognitoIdp, USER_POOL_ID, cacheManager);
+    eventPublishService = mock(EventPublishService.class);
+
+    service = new UserAccountService(cognitoIdp, USER_POOL_ID, cacheManager, eventPublishService);
 
     // Initialize groups as an empty list instead of null, which reflects default AWS API behaviour.
     AdminListGroupsForUserResult mockGroupResult = new AdminListGroupsForUserResult();
@@ -289,20 +293,35 @@ class UserAccountServiceTest {
   void shouldUpdateEmailWhenNewEmailNotExistsInUserPool() {
     String newEmail = "new.email@example.com";
 
-    when(cognitoIdp.adminGetUser(any())).thenThrow(UserNotFoundException.class);
+    ArgumentCaptor<AdminGetUserRequest> getRequestCaptor = ArgumentCaptor.forClass(
+        AdminGetUserRequest.class);
+    when(cognitoIdp.adminGetUser(getRequestCaptor.capture()))
+        .thenThrow(UserNotFoundException.class)
+        .thenReturn(new AdminGetUserResult()
+            .withUserAttributes(new AttributeType()
+                .withName("name")
+                .withValue("value")
+            )
+        );
 
     service.updateEmail(USER_ID_1, newEmail);
 
-    ArgumentCaptor<AdminUpdateUserAttributesRequest> requestCaptor = ArgumentCaptor.forClass(
+    List<AdminGetUserRequest> getRequests = getRequestCaptor.getAllValues();
+    assertThat("Unexpected get request count.", getRequests.size(), is(2));
+
+    AdminGetUserRequest getRequest = getRequests.get(0);
+    assertThat("Unexpected username.", getRequest.getUsername(), is(newEmail));
+
+    ArgumentCaptor<AdminUpdateUserAttributesRequest> updateRequestCaptor = ArgumentCaptor.forClass(
         AdminUpdateUserAttributesRequest.class);
-    verify(cognitoIdp).adminUpdateUserAttributes(requestCaptor.capture());
+    verify(cognitoIdp).adminUpdateUserAttributes(updateRequestCaptor.capture());
 
-    AdminUpdateUserAttributesRequest request = requestCaptor.getValue();
+    AdminUpdateUserAttributesRequest updateRequest = updateRequestCaptor.getValue();
 
-    assertThat("Unexpected user pool.", request.getUserPoolId(), is(USER_POOL_ID));
-    assertThat("Unexpected user ID.", request.getUsername(), is(USER_ID_1));
+    assertThat("Unexpected user pool.", updateRequest.getUserPoolId(), is(USER_POOL_ID));
+    assertThat("Unexpected user ID.", updateRequest.getUsername(), is(USER_ID_1));
 
-    List<AttributeType> userAttributes = request.getUserAttributes();
+    List<AttributeType> userAttributes = updateRequest.getUserAttributes();
     assertThat("Unexpected attribute count.", userAttributes.size(), is(2));
 
     AttributeType userAttribute = userAttributes.get(0);
@@ -312,6 +331,33 @@ class UserAccountServiceTest {
     userAttribute = userAttributes.get(1);
     assertThat("Unexpected attribute name.", userAttribute.getName(), is("email_verified"));
     assertThat("Unexpected attribute value.", userAttribute.getValue(), is("true"));
+  }
+
+  @Test
+  void shouldPublishEventAfterUpdatingEmail() {
+    String previousEmail = "previous.email@example.com";
+    String newEmail = "new.email@example.com";
+
+    ArgumentCaptor<AdminGetUserRequest> getRequestCaptor = ArgumentCaptor.forClass(
+        AdminGetUserRequest.class);
+    when(cognitoIdp.adminGetUser(getRequestCaptor.capture()))
+        .thenThrow(UserNotFoundException.class)
+        .thenReturn(new AdminGetUserResult()
+            .withUserAttributes(new AttributeType()
+                .withName("email")
+                .withValue(previousEmail)
+            )
+        );
+
+    service.updateEmail(USER_ID_1, newEmail);
+
+    List<AdminGetUserRequest> getRequests = getRequestCaptor.getAllValues();
+    assertThat("Unexpected get request count.", getRequests.size(), is(2));
+
+    AdminGetUserRequest getRequest = getRequests.get(1);
+    assertThat("Unexpected username.", getRequest.getUsername(), is(USER_ID_1));
+
+    verify(eventPublishService).publishEmailUpdateEvent(USER_ID_1, previousEmail, newEmail);
   }
 
   @Test


### PR DESCRIPTION
When a user account is updated to change the email, an event should be published including the original and new email addresses.

TIS21-6006
TIS21-6009
TIS21-6010