### PR TITLE
feat!: replace DSP consultants with generic group

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -53,8 +53,8 @@
           "valueFrom": "/tis/trainee/sync/${environment}/queue-url-fifo"
         },
         {
-          "name": "COGNITO_DSP_CONSULTANT_GROUP",
-          "valueFrom": "/tis/trainee/cognito/${environment}/dsp-consultant-group"
+          "name": "BETA_PARTICIPANT_GROUP",
+          "valueFrom": "/tis/trainee/cognito/${environment}/beta-participant-group"
         },
         {
           "name": "USER_ACCOUNT_UPDATE_EVENT_TOPIC",

--- a/README.md
+++ b/README.md
@@ -19,24 +19,24 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name                            | Description                                             | Default   |
-|---------------------------------|---------------------------------------------------------|-----------|
-| AWS_REGION                      | The AWS region to use.                                  |           |
-| AWS_XRAY_DAEMON_ADDRESS         | The AWS XRay daemon host.                               |           |
-| COGNITO_DSP_CONSULTANT_GROUP    | The name of the Cognito user group for DSP consultants. |           |
-| COGNITO_USER_POOL_ID            | The ID of the Cognito user pool to manage.              |           |
-| CONTACT_DETAILS_UPDATED_QUEUE   | The ARN of a queue to received contact detail events.   |           |
-| ENVIRONMENT                     | The environment to log events against.                  | local     |
-| PROFILE_HOST                    | The host of TIS-Profile service.                        | localhost |
-| PROFILE_PORT                    | The port number of TIS-Profile service.                 | 8082      |
-| REDIS_HOST                      | Redis server host                                       | localhost |
-| REDIS_PASSWORD                  | Login password of the redis server.                     | password  |
-| REDIS_PORT                      | Redis server port.                                      | 6379      |
-| REDIS_SSL                       | Whether to enable SSL support.                          | false     |
-| REDIS_USERNAME                  | Login username of the redis server                      | default   |
-| REQUEST_QUEUE_URL               | The URL of sync request queue.                          |           |
-| SENTRY_DSN                      | A Sentry error monitoring Data Source Name.             |           |
-| USER_ACCOUNT_UPDATE_EVENT_TOPIC | The topic ARN to publish user account update events to. |           |
+| Name                            | Description                                               | Default   |
+|---------------------------------|-----------------------------------------------------------|-----------|
+| AWS_REGION                      | The AWS region to use.                                    |           |
+| AWS_XRAY_DAEMON_ADDRESS         | The AWS XRay daemon host.                                 |           |
+| BETA_PARTICIPANT_GROUP          | The name of the Cognito user group for beta participants. |           |
+| COGNITO_USER_POOL_ID            | The ID of the Cognito user pool to manage.                |           |
+| CONTACT_DETAILS_UPDATED_QUEUE   | The ARN of a queue to received contact detail events.     |           |
+| ENVIRONMENT                     | The environment to log events against.                    | local     |
+| PROFILE_HOST                    | The host of TIS-Profile service.                          | localhost |
+| PROFILE_PORT                    | The port number of TIS-Profile service.                   | 8082      |
+| REDIS_HOST                      | Redis server host                                         | localhost |
+| REDIS_PASSWORD                  | Login password of the redis server.                       | password  |
+| REDIS_PORT                      | Redis server port.                                        | 6379      |
+| REDIS_SSL                       | Whether to enable SSL support.                            | false     |
+| REDIS_USERNAME                  | Login username of the redis server                        | default   |
+| REQUEST_QUEUE_URL               | The URL of sync request queue.                            |           |
+| SENTRY_DSN                      | A Sentry error monitoring Data Source Name.               |           |
+| USER_ACCOUNT_UPDATE_EVENT_TOPIC | The topic ARN to publish user account update events to.   |           |
 
 #### Usage Examples
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "1.7.0"
+version = "2.0.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/api/UserGroupsResource.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/api/UserGroupsResource.java
@@ -41,37 +41,37 @@ import uk.nhs.tis.trainee.usermanagement.service.UserAccountService;
 public class UserGroupsResource {
 
   private final UserAccountService service;
-  private final String dspConsultantGroupName;
+  private final String betaParticipantGroupName;
 
   UserGroupsResource(UserAccountService service,
-      @Value("${application.aws.cognito.dsp-consultant-group}") String dspConsultantGroupName) {
+      @Value("${application.aws.cognito.beta-participant-group}") String betaParticipantGroupName) {
     this.service = service;
-    this.dspConsultantGroupName = dspConsultantGroupName;
+    this.betaParticipantGroupName = betaParticipantGroupName;
   }
 
   /**
-   * Add the given user into DSP Beta consultation group.
+   * Add the given user into Beta Participant group.
    *
    * @param username The username of the user.
    * @return 204 No Content, if successful.
    */
-  @PostMapping("/dsp-consultants/enroll/{username}")
-  ResponseEntity<Void> enrollDspConsultationGroup(@PathVariable String username) {
-    log.info("User '{}' enrollment to DSP Beta Consultation group requested.", username);
-    service.enrollToUserGroup(username, dspConsultantGroupName);
+  @PostMapping("/beta-participants/enroll/{username}")
+  ResponseEntity<Void> enrollBetaParticipantGroup(@PathVariable String username) {
+    log.info("User '{}' enrollment to Beta Participant group requested.", username);
+    service.enrollToUserGroup(username, betaParticipantGroupName);
     return ResponseEntity.noContent().build();
   }
 
   /**
-   * Remove the given user from DSP Beta consultation group.
+   * Remove the given user from Beta Participant group.
    *
    * @param username The username of the user.
    * @return 204 No Content, if successful.
    */
-  @PostMapping("/dsp-consultants/withdraw/{username}")
-  ResponseEntity<Void> withdrawDspConsultationGroup(@PathVariable String username) {
-    log.info("User '{}' withdrawal from DSP Beta Consultation group requested.", username);
-    service.withdrawFromUserGroup(username, dspConsultantGroupName);
+  @PostMapping("/beta-participants/withdraw/{username}")
+  ResponseEntity<Void> withdrawBetaParticipantGroup(@PathVariable String username) {
+    log.info("User '{}' withdrawal from Beta Participant group requested.", username);
+    service.withdrawFromUserGroup(username, betaParticipantGroupName);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ application:
   aws:
     cognito:
       user-pool-id: ${COGNITO_USER_POOL_ID}
-      dsp-consultant-group: ${COGNITO_DSP_CONSULTANT_GROUP}
+      beta-participant-group: ${BETA_PARTICIPANT_GROUP}
     sns:
       user-account:
         update: ${USER_ACCOUNT_UPDATE_EVENT_TOPIC:}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/api/UserGroupsResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/api/UserGroupsResourceTest.java
@@ -36,7 +36,7 @@ import uk.nhs.tis.trainee.usermanagement.service.UserAccountService;
 class UserGroupsResourceTest {
 
   private static final String USERNAME = "username";
-  private static final String DSP_CONSULTANT_GROUP = "dsp-consultant-group";
+  private static final String BETA_PARTICIPANT_GROUP = "beta-participant-group";
 
   private MockMvc mockMvc;
   private UserAccountService service;
@@ -44,25 +44,25 @@ class UserGroupsResourceTest {
   @BeforeEach
   void setUp() {
     service = mock(UserAccountService.class);
-    UserGroupsResource resource = new UserGroupsResource(service, DSP_CONSULTANT_GROUP);
+    UserGroupsResource resource = new UserGroupsResource(service, BETA_PARTICIPANT_GROUP);
     mockMvc = MockMvcBuilders.standaloneSetup(resource).build();
   }
 
   @Test
-  void shouldEnrollDspConsultationGroup() throws Exception {
-    mockMvc.perform(post("/api/user-groups/dsp-consultants/enroll/{username}", USERNAME)
+  void shouldEnrollBetaParticipationGroup() throws Exception {
+    mockMvc.perform(post("/api/user-groups/beta-participants/enroll/{username}", USERNAME)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent());
 
-    verify(service).enrollToUserGroup(USERNAME, DSP_CONSULTANT_GROUP);
+    verify(service).enrollToUserGroup(USERNAME, BETA_PARTICIPANT_GROUP);
   }
 
   @Test
-  void shouldWithdrawDspConsultation() throws Exception {
-    mockMvc.perform(post("/api/user-groups/dsp-consultants/withdraw/{username}", USERNAME)
+  void shouldWithdrawBetaParticipant() throws Exception {
+    mockMvc.perform(post("/api/user-groups/beta-participants/withdraw/{username}", USERNAME)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent());
 
-    verify(service).withdrawFromUserGroup(USERNAME, DSP_CONSULTANT_GROUP);
+    verify(service).withdrawFromUserGroup(USERNAME, BETA_PARTICIPANT_GROUP);
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,7 +2,7 @@ application:
   aws:
     cognito:
       user-pool-id: eu-west-2_dummy
-      dsp-consultant-group: test_group
+      beta-participant-group: test_group
 
 cloud:
   aws:


### PR DESCRIPTION
BREAKING CHANGE: The DSP consultant group has been removed, so the existing enrollment endpoints for the DSP beta have been removed too. In their place is a more generic "Beta Participant" group with new endpoints at `/api/user-groups/beta-participants/*`

TIS21-6715
TIS21-6811