### PR TITLE
fix: tracing configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.0.0"
+version = "2.0.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AwsXrayInterceptor.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/AwsXrayInterceptor.java
@@ -34,8 +34,7 @@ import org.springframework.stereotype.Component;
 public class AwsXrayInterceptor extends AbstractXRayInterceptor {
 
   @Override
-  @Pointcut(
-      "@within(com.amazonaws.xray.spring.aop.XRayEnabled) && (bean(*Resource) || bean(*Service))")
+  @Pointcut("@within(com.amazonaws.xray.spring.aop.XRayEnabled) && bean(*Resource)")
   public void xrayEnabledClasses() {
 
   }


### PR DESCRIPTION
The AWS X-Ray interceptor is configured to wrap Service classes, but when the service class is called from an SQS Listener the trace segments are not instrumented which causes errors in the logs.

Remove the wrapping of the service beans, leaving just the resource beans. The service calls will still appear in the traces but they will not attempt to be wrapped.

NO-TICKET