### PR TITLE
fix: include user IDs in multiple account error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.0.1"
+version = "2.0.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListener.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListener.java
@@ -61,8 +61,9 @@ public class ContactDetailsListener {
         service.updateEmail(accountId, dto.email());
       }
       default -> {
-        String message = String.format("%s accounts found for trainee %s, unable to update email.",
-            userAccountIds.size(), traineeId);
+        String message = String.format(
+            "%s accounts found for trainee %s, unable to update email. Found: [%s]",
+            userAccountIds.size(), traineeId, String.join(",", userAccountIds));
         throw new IllegalArgumentException(message);
       }
     }


### PR DESCRIPTION
When attempting to update an email an exception is throw if multiple accounts are found for a given trainee ID.
The current expection message says how many were found, but it is challenging to query for `custom:tisId` to identify problem accounts.

Update ContactDetailsListener to include the found user IDs in the error message. This should allow us to take appropriate action when these sorts of errors occur.

NO-TICKET