### PR TITLE
feat: delete duplicate accounts on email update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.0.3"
+version = "2.1.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/ContactDetailsDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/ContactDetailsDto.java
@@ -33,7 +33,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * @param surname   The new surname from the contact details.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record ContactDetailsDto(@JsonAlias("id")
-  String traineeId, String email, String forenames, String surname) {
+public record ContactDetailsDto(
+    @JsonAlias("id")
+    String traineeId,
+    String email,
+    String forenames,
+    String surname) {
 
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/UserAccountDetailsDto.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/dto/UserAccountDetailsDto.java
@@ -28,6 +28,7 @@ import lombok.Value;
 @Value
 public class UserAccountDetailsDto {
 
+  String username;
   String mfaStatus;
   String userStatus;
   List<String> groups;

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/api/UserAccountResourceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/api/UserAccountResourceTest.java
@@ -74,8 +74,8 @@ class UserAccountResourceTest {
 
   @Test
   void shouldReturnExistenceFalseWhenUserAccountNotExists() throws Exception {
-    UserAccountDetailsDto userAccountDetails = new UserAccountDetailsDto("NO_ACCOUNT", "NO_ACCOUNT",
-        List.of(), null);
+    UserAccountDetailsDto userAccountDetails = new UserAccountDetailsDto(USERNAME, "NO_ACCOUNT",
+        "NO_ACCOUNT", List.of(), null);
 
     when(service.getUserAccountDetails(USERNAME)).thenReturn(userAccountDetails);
 
@@ -88,7 +88,7 @@ class UserAccountResourceTest {
 
   @Test
   void shouldReturnExistenceTrueWhenUserAccountExists() throws Exception {
-    UserAccountDetailsDto userAccountDetails = new UserAccountDetailsDto("MFA_STATUS",
+    UserAccountDetailsDto userAccountDetails = new UserAccountDetailsDto(USERNAME, "MFA_STATUS",
         "USER_STATUS", List.of(), Instant.now());
 
     when(service.getUserAccountDetails(USERNAME)).thenReturn(userAccountDetails);
@@ -104,7 +104,7 @@ class UserAccountResourceTest {
   void shouldGetUserAccountDetails() throws Exception {
     List<String> groups = List.of("GROUP_1", "GROUP_2");
     Instant accountCreated = Instant.now();
-    UserAccountDetailsDto userAccountDetails = new UserAccountDetailsDto("MFA_STATUS",
+    UserAccountDetailsDto userAccountDetails = new UserAccountDetailsDto(USERNAME, "MFA_STATUS",
         "USER_STATUS", groups, accountCreated);
 
     when(service.getUserAccountDetails(USERNAME)).thenReturn(userAccountDetails);
@@ -112,6 +112,7 @@ class UserAccountResourceTest {
     mockMvc.perform(get("/api/user-account/details/{username}", USERNAME)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andExpect(jsonPath("$.username").value(USERNAME))
         .andExpect(jsonPath("$.mfaStatus").value("MFA_STATUS"))
         .andExpect(jsonPath("$.userStatus").value("USER_STATUS"))
         .andExpect(jsonPath("$.groups").isArray())


### PR DESCRIPTION
When contact details are updated the trainee's account is updated to change the log-in email. Currently this update is rejected if there are multiple accounts for the trainee, based on the Person ID. Update the ContactDetailsListener and UserAccountService to attempt to delete the duplicate accounts, before finalising the email update.

The initial rule for deletion is to retain any account that matches the current contact email address, deleting the other duplicates. Further rules will be added over time once the remaining scenarios can be identified.

TIS21-7288