### PR TITLE
refactor: remove calls to Cognito `adminGetUser`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.1.0"
+version = "2.1.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
The Cognito `adminGetUser` endpoint contributes towards monthly active users (MAU) and counts towards monthly billing.
The current usage triggers a large cost when reloading the contact details table as the `adminGetUser` endpoint is used to check the existence of accounts, as well as other basic attributes.

The UserAccountService should be refactored to minimise the use of `adminGetUser`, using `listUsers` with strict filtering as an alternative.
Create `UserAccountService.getUser()` as a thin wrapper around Cognito's `listUsers` endpoint, it should take a `sub` or `email` value and otherwise behave the same as `adminGetUser` does when searching by username.

The remaining calls to `adminGetUser` are required due to the need for MFA preference data, however these are tied to administrator API calls for individual records rather than bulk/automated operations. Further refactoring could be done to store MFA preferences elsewhere, or try and infer them (e.g. verified phone = SMS, else TOTP) but additional changes would be required to ensure consistent data, such as deleting phone numbers when resetting MFA.

NO-TICKET