### PR TITLE
feat: set custom:mfaType to NO_MFA on MFA reset

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.1.1"
+version = "2.2.0"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
When a user's MFA is reset the `custom:mfaType` attribute should be set to `NO_MFA`.

TIS21-7256
TIS21-7391