### PR TITLE
fix: catch UserNotFoundException finding dupes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.3.0"
+version = "2.3.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
@@ -281,8 +281,15 @@ public class UserAccountService {
    */
   private String identifyMainAccount(String traineeId, Set<String> accountIds,
       String currentEmail) {
-    UserAccountDetailsDto currentEmailAccount = cognitoService.getUserDetails(currentEmail);
-    String currentEmailId = currentEmailAccount.getId();
+    String currentEmailId = null;
+
+    try {
+      UserAccountDetailsDto currentEmailAccount = cognitoService.getUserDetails(currentEmail);
+      currentEmailId = currentEmailAccount.getId();
+    } catch (UserNotFoundException e) {
+      log.info("No existing account found for trainee {} matching current TIS email '{}'.",
+          traineeId, currentEmail);
+    }
 
     if (currentEmailId != null && accountIds.contains(currentEmailId)) {
       log.info("Found existing account {} for trainee {} matching current TIS email '{}'.",


### PR DESCRIPTION
When trying to de-duplicate accounts, if the new TIS email does not match an existing account an exception is thrown. This scenario should be handled more gracefully, with the exception caught and treated as no main account found.

The auth events should still be checked so that successless accounts can be identified.

TIS21-7288