### PR TITLE
fix: support EMAIL_OTP MFA type

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.3.1"
+version = "2.3.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/enumeration/MfaType.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/enumeration/MfaType.java
@@ -22,10 +22,9 @@
 package uk.nhs.tis.trainee.usermanagement.enumeration;
 
 import com.amazonaws.services.cognitoidp.model.AdminGetUserResult;
-import com.amazonaws.services.cognitoidp.model.ChallengeNameType;
 
 public enum MfaType {
-  NO_MFA, SMS_MFA, SOFTWARE_TOKEN_MFA;
+  EMAIL_OTP, NO_MFA, SMS_MFA, SOFTWARE_TOKEN_MFA;
 
   /**
    * Get the MFA type from an {@link AdminGetUserResult}.
@@ -40,11 +39,12 @@ public enum MfaType {
       return NO_MFA;
     }
 
-    return switch (ChallengeNameType.fromValue(preferredMfaSetting)) {
-      case SMS_MFA -> SMS_MFA;
-      case SOFTWARE_TOKEN_MFA -> SOFTWARE_TOKEN_MFA;
-      default -> throw new IllegalArgumentException(
+    // TODO: revert to check valid Cognito ChallengeNameType values once the SDK is upgraded.
+    if (preferredMfaSetting.equals(NO_MFA.toString())) {
+      throw new IllegalArgumentException(
           "Cannot create enum from " + preferredMfaSetting + " value!");
-    };
+    }
+
+    return MfaType.valueOf(preferredMfaSetting);
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/enumeration/MfaTypeTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/enumeration/MfaTypeTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.amazonaws.services.cognitoidp.model.AdminGetUserResult;
-import com.amazonaws.services.cognitoidp.model.ChallengeNameType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -44,13 +43,13 @@ class MfaTypeTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', nullValues = "null", textBlock = """
+      EMAIL_OTP          | EMAIL_OTP
       SMS_MFA            | SMS_MFA
       SOFTWARE_TOKEN_MFA | SOFTWARE_TOKEN_MFA
       null               | NO_MFA
       """)
-  void shouldReturnMfaTypeForValidPreferredMfa(ChallengeNameType preferredMfa, MfaType expected) {
-    AdminGetUserResult result = new AdminGetUserResult()
-        .withPreferredMfaSetting(preferredMfa == null ? null : preferredMfa.toString());
+  void shouldReturnMfaTypeForValidPreferredMfa(String preferredMfa, MfaType expected) {
+    AdminGetUserResult result = new AdminGetUserResult().withPreferredMfaSetting(preferredMfa);
 
     MfaType mfaType = MfaType.fromAdminGetUserResult(result);
 

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/CognitoServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/CognitoServiceTest.java
@@ -55,7 +55,6 @@ import com.amazonaws.services.cognitoidp.model.AdminSetUserMFAPreferenceRequest;
 import com.amazonaws.services.cognitoidp.model.AdminSetUserMFAPreferenceResult;
 import com.amazonaws.services.cognitoidp.model.AdminUpdateUserAttributesRequest;
 import com.amazonaws.services.cognitoidp.model.AttributeType;
-import com.amazonaws.services.cognitoidp.model.ChallengeNameType;
 import com.amazonaws.services.cognitoidp.model.GroupType;
 import com.amazonaws.services.cognitoidp.model.ListUsersRequest;
 import com.amazonaws.services.cognitoidp.model.ListUsersResult;
@@ -225,7 +224,7 @@ class CognitoServiceTest {
                 new AttributeType().withName(ATTRIBUTE_EMAIL).withValue(EMAIL),
                 new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID)
             ))
-            .withPreferredMfaSetting(ChallengeNameType.SOFTWARE_TOKEN_MFA.toString())
+            .withPreferredMfaSetting(SOFTWARE_TOKEN_MFA.toString())
             .withUserCreateDate(Date.from(CREATED))
             .withUserStatus(CONFIRMED)
     );
@@ -245,19 +244,19 @@ class CognitoServiceTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', nullValues = "null", textBlock = """
+      EMAIL_OTP          | EMAIL_OTP
       SMS_MFA            | SMS_MFA
       SOFTWARE_TOKEN_MFA | SOFTWARE_TOKEN_MFA
       null               | NO_MFA
       """)
   void shouldPopulateCustomMfaTypeFromAdminGetUserWhenCustomMfaNotSet(
-      ChallengeNameType preferredMfa, MfaType mfaType) {
+      String preferredMfa, MfaType mfaType) {
     when(cognitoIdp.listUsers(any())).thenReturn(new ListUsersResult().withUsers(
         new UserType().withAttributes(List.of())
     ));
 
     when(cognitoIdp.adminGetUser(any())).thenReturn(
-        new AdminGetUserResult().withPreferredMfaSetting(
-            preferredMfa == null ? null : preferredMfa.toString())
+        new AdminGetUserResult().withPreferredMfaSetting(preferredMfa)
     );
 
     service.getUserDetails(USER_ID);
@@ -294,7 +293,7 @@ class CognitoServiceTest {
                 new AttributeType().withName(ATTRIBUTE_EMAIL).withValue(EMAIL),
                 new AttributeType().withName(ATTRIBUTE_TRAINEE_ID).withValue(TRAINEE_ID)
             ))
-            .withPreferredMfaSetting(ChallengeNameType.SOFTWARE_TOKEN_MFA.toString())
+            .withPreferredMfaSetting(SOFTWARE_TOKEN_MFA.toString())
             .withUserCreateDate(Date.from(CREATED))
             .withUserStatus(CONFIRMED)
     );
@@ -314,11 +313,12 @@ class CognitoServiceTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', nullValues = "null", textBlock = """
+      EMAIL_OTP          | EMAIL_OTP
       SMS_MFA            | SMS_MFA
       SOFTWARE_TOKEN_MFA | SOFTWARE_TOKEN_MFA
       null               | NO_MFA
       """)
-  void shouldPopulateCustomMfaTypeFromAdminGetUserWhenCustomMfaNoMfa(ChallengeNameType preferredMfa,
+  void shouldPopulateCustomMfaTypeFromAdminGetUserWhenCustomMfaNoMfa(String preferredMfa,
       MfaType mfaType) {
     when(cognitoIdp.listUsers(any())).thenReturn(new ListUsersResult().withUsers(
         new UserType()
@@ -328,8 +328,7 @@ class CognitoServiceTest {
     ));
 
     when(cognitoIdp.adminGetUser(any())).thenReturn(
-        new AdminGetUserResult().withPreferredMfaSetting(
-            preferredMfa == null ? null : preferredMfa.toString())
+        new AdminGetUserResult().withPreferredMfaSetting(preferredMfa)
     );
 
     service.getUserDetails(USER_ID);
@@ -386,18 +385,17 @@ class CognitoServiceTest {
 
   @ParameterizedTest
   @CsvSource(delimiter = '|', nullValues = "null", textBlock = """
+      EMAIL_OTP          | EMAIL_OTP
       SMS_MFA            | SMS_MFA
       SOFTWARE_TOKEN_MFA | SOFTWARE_TOKEN_MFA
       null               | NO_MFA
       """)
-  void shouldConvertAwsMfaPreferenceWhenGettingUserDetails(ChallengeNameType preferredMfa,
-      MfaType mfaType) {
+  void shouldConvertAwsMfaPreferenceWhenGettingUserDetails(String preferredMfa, MfaType mfaType) {
     when(cognitoIdp.listUsers(any())).thenReturn(new ListUsersResult().withUsers(
         new UserType().withAttributes(List.of())
     ));
 
-    AdminGetUserResult result = new AdminGetUserResult().withPreferredMfaSetting(
-        preferredMfa == null ? null : preferredMfa.toString());
+    AdminGetUserResult result = new AdminGetUserResult().withPreferredMfaSetting(preferredMfa);
 
     when(cognitoIdp.adminGetUser(any())).thenReturn(result);
 


### PR DESCRIPTION
Update MfaType enumeration to support `EMAIL_OTP` challenge type.

Support for `EMAIL_OTP` in the Cognito library's `ChallengeNameType` enumeration requires v2 of the SDK, which is a significant refactor. To avoid such widespread code changes the MfaType enumeration should be refactored to directly support the value without Cognito library changes.

This does remove the guard rails that ensure we are being given valid values, so a TODO has been added to revert the MfaType changes once SDK v2 refactor has been done.

TIS21-7501