### PR TITLE
chore(deps): bump `profile-client` version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.4.0"
+version = "2.4.1"
 
 configurations {
   compileOnly {
@@ -33,7 +33,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
 
   implementation("com.transformuk.hee:tis-security-jwt:6.0.0-SNAPSHOT")
-  implementation("com.transformuk.hee:profile-client:3.4.0") {
+  implementation("com.transformuk.hee:profile-client:3.4.1") {
     exclude("com.fasterxml.jackson.module", "jackson-module-jaxb-annotations")
   }
 


### PR DESCRIPTION
Bump the version of `profile-client` to one which no longer uses Spring Security's JwtHelper, which is not available in the used version.

TIS21-6233
TIS21-6308