### PR TITLE
fix: redis property names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.4.1"
+version = "2.4.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,13 +31,15 @@ spring:
         static: ${AWS_REGION}
       cloudwatch:
         namespace: TIS/Trainee/UserManagement
-  redis:
-    host: ${REDIS_HOST:localhost}
-    port: ${REDIS_PORT:6379}
-    ssl: ${REDIS_SSL:false}
-    username: ${REDIS_USERNAME:default}
-    password: ${REDIS_PASSWORD:password}
-    timeout: 60000
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      ssl:
+        enabled: ${REDIS_SSL:false}
+      username: ${REDIS_USERNAME:default}
+      password: ${REDIS_PASSWORD:password}
+      timeout: 60000
 
 profile:
   server:


### PR DESCRIPTION
The redis properties are nested under `spring.redis` but should be `spring.data.redis`.
They are correctly nested in the test application properties which covered up the issue in automated tests.

NO-TICKET