### PR TITLE
feat: audit trail for changed account emails

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -17,6 +17,22 @@
           "valueFrom": "/tis/trainee/user-management/${environment}/queue-url/contact-details/updated"
         },
         {
+          "name": "DB_HOST",
+          "valueFrom": "/tis/trainee/${environment}/db/host"
+        },
+        {
+          "name": "DB_PORT",
+          "valueFrom": "/tis/trainee/${environment}/db/port"
+        },
+        {
+          "name": "DB_USER",
+          "valueFrom": "/tis/trainee/${environment}/db/username"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "/tis/trainee/${environment}/db/password"
+        },
+        {
           "name": "REDIS_HOST",
           "valueFrom": "/tis/core/${environment}/redis/host"
         },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.5.1"
+version = "2.6.0"
 
 configurations {
   compileOnly {
@@ -28,6 +28,7 @@ dependencyManagement {
 dependencies {
   // Spring Boot starters
   implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
   implementation("org.springframework.boot:spring-boot-starter-data-redis")
   implementation("org.springframework.boot:spring-boot-starter-web")
   implementation("org.springframework.boot:spring-boot-starter-security")
@@ -64,9 +65,11 @@ dependencies {
   implementation("io.micrometer:micrometer-registry-cloudwatch2")
 
   testImplementation("org.springframework.boot:spring-boot-starter-test")
-  testImplementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
-  testImplementation("com.playtika.testcontainers:embedded-redis:3.1.16")
+  testImplementation("org.springframework.boot:spring-boot-testcontainers")
   testImplementation("org.testcontainers:junit-jupiter")
+  testImplementation("org.testcontainers:localstack")
+  testImplementation("org.testcontainers:mongodb")
+  testImplementation("com.redis:testcontainers-redis")
 }
 
 java {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/config/MongoConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,36 +19,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.usermanagement;
+package uk.nhs.tis.trainee.usermanagement.config;
 
-import io.awspring.cloud.sns.core.SnsTemplate;
-import io.awspring.cloud.sqs.operations.SqsTemplate;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
+import java.util.UUID;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeUserManagementApplicationTest {
+/**
+ * Configuration class for MongoDB settings and callbacks.
+ */
+@Configuration
+@EnableMongoAuditing
+public class MongoConfiguration {
 
-  // Could not get it working with the standard mocks, so full container it is.
-  @Container
-  @ServiceConnection
-  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
-      DockerImageNames.MONGO);
-
-  @MockitoBean
-  private SnsTemplate snsTemplate;
-
-  @MockitoBean
-  private SqsTemplate sqsTemplate;
-
-  @Test
-  void contextLoads() {
-
+  /**
+   * Generates a random UUID for the ID field of an AccountEvent if it is not already set before
+   * saving to MongoDB.
+   *
+   * @return a BeforeConvertCallback that sets the ID of an AccountEvent to a random UUID if it is
+   *     null.
+   */
+  @Bean
+  public BeforeConvertCallback<AccountEvent> accountEventBeforeConvertCallback() {
+    return (entity, collection) -> entity.id() == null ? entity.withId(UUID.randomUUID()) : entity;
   }
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/model/AccountEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/model/AccountEvent.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.model;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.With;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * Represents an event that occurred to a user account, such as email update or password reset.
+ *
+ * @param id        The unique identifier of the event.
+ * @param userId    The ID of the user whose account was affected.
+ * @param traineeId The ID of the trainee associated with the user account.
+ * @param type      The type of the event, e.g. EMAIL_UPDATED.
+ * @param detail    Additional details about the event, such as the old and new email addresses for
+ *                  an email update event.
+ * @param created   The time the event occurred.
+ */
+@Document
+@Builder
+public record AccountEvent(
+    @Id
+    @With
+    UUID id,
+
+    @Indexed
+    String userId,
+
+    @Indexed
+    String traineeId,
+
+    AccountEventType type,
+    AccountEventDetail detail,
+
+    @CreatedDate
+    Instant created) {
+
+  /**
+   * Marker interface for additional details about an account event.
+   */
+  public interface AccountEventDetail {
+
+  }
+
+  /**
+   * Details for an email update event, containing the old and new email addresses.
+   *
+   * @param before The email address before the update.
+   * @param after  The email address after the update.
+   */
+  @Builder
+  public record EmailUpdatedDetail(String before, String after) implements AccountEventDetail {
+
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/model/AccountEventType.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/model/AccountEventType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,36 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.usermanagement;
+package uk.nhs.tis.trainee.usermanagement.model;
 
-import io.awspring.cloud.sns.core.SnsTemplate;
-import io.awspring.cloud.sqs.operations.SqsTemplate;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeUserManagementApplicationTest {
-
-  // Could not get it working with the standard mocks, so full container it is.
-  @Container
-  @ServiceConnection
-  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
-      DockerImageNames.MONGO);
-
-  @MockitoBean
-  private SnsTemplate snsTemplate;
-
-  @MockitoBean
-  private SqsTemplate sqsTemplate;
-
-  @Test
-  void contextLoads() {
-
-  }
+/**
+ * An enumeration of account event types.
+ */
+public enum AccountEventType {
+  EMAIL_UPDATED
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/repository/AccountEventRepository.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/repository/AccountEventRepository.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,36 +19,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.usermanagement;
+package uk.nhs.tis.trainee.usermanagement.repository;
 
-import io.awspring.cloud.sns.core.SnsTemplate;
-import io.awspring.cloud.sqs.operations.SqsTemplate;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
+import java.util.UUID;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeUserManagementApplicationTest {
+/**
+ * Repository for {@link AccountEvent} entities.
+ */
+public interface AccountEventRepository extends MongoRepository<AccountEvent, UUID> {
 
-  // Could not get it working with the standard mocks, so full container it is.
-  @Container
-  @ServiceConnection
-  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
-      DockerImageNames.MONGO);
-
-  @MockitoBean
-  private SnsTemplate snsTemplate;
-
-  @MockitoBean
-  private SqsTemplate sqsTemplate;
-
-  @Test
-  void contextLoads() {
-
-  }
 }

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/AuditService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/AuditService.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.service;
+
+import static uk.nhs.tis.trainee.usermanagement.model.AccountEventType.EMAIL_UPDATED;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent.EmailUpdatedDetail;
+import uk.nhs.tis.trainee.usermanagement.repository.AccountEventRepository;
+
+/**
+ * A service for recording audit events related to user accounts.
+ */
+@Slf4j
+@Service
+public class AuditService {
+
+  private final AccountEventRepository repository;
+
+  public AuditService(AccountEventRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Records an email update event for a user account.
+   *
+   * @param userId    The ID of the user whose email was updated.
+   * @param traineeId The ID of the trainee associated with the user account.
+   * @param oldEmail  The old email address.
+   * @param newEmail  The new email address.
+   */
+  public void accountEmailUpdated(String userId, String traineeId, String oldEmail,
+      String newEmail) {
+    log.debug("Recording email update for user {} with trainee ID {}.", userId, traineeId);
+    EmailUpdatedDetail emailUpdatedDetail = new EmailUpdatedDetail(oldEmail, newEmail);
+    AccountEvent event = AccountEvent.builder()
+        .userId(userId)
+        .traineeId(traineeId)
+        .type(EMAIL_UPDATED)
+        .detail(emailUpdatedDetail)
+        .build();
+    repository.insert(event);
+  }
+}

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
@@ -84,6 +84,7 @@ public class UserAccountService {
   private final String userPoolId;
   private final Cache cache;
 
+  private final AuditService auditService;
   private final EventPublishService eventPublishService;
 
   private Instant lastUserCaching = null;
@@ -91,12 +92,13 @@ public class UserAccountService {
   UserAccountService(CognitoService cognitoService,
       @Value("${application.aws.cognito.user-pool-id}") String userPoolId,
       CacheManager cacheManager, EventPublishService eventPublishService,
-      MetricsService metricsService) {
+      MetricsService metricsService, AuditService auditService) {
     this.cognitoService = cognitoService;
     this.userPoolId = userPoolId;
     cache = cacheManager.getCache(USER_ID_CACHE);
     this.eventPublishService = eventPublishService;
     this.metricsService = metricsService;
+    this.auditService = auditService;
   }
 
   /**
@@ -161,6 +163,7 @@ public class UserAccountService {
       UserAccountDetailsDto existingUser = getUserAccountDetails(userId);
       String traineeId = existingUser.getTraineeId();
       String existingEmail = existingUser.getEmail();
+      auditService.accountEmailUpdated(userId, traineeId, existingEmail, newEmail);
       eventPublishService.publishEmailUpdateEvent(userId, traineeId, existingEmail, newEmail);
       log.info("Successfully updated email to '{}' for user '{}'.", newEmail, userId);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,10 @@ spring:
       cloudwatch:
         namespace: TIS/Trainee/UserManagement
   data:
+    mongodb:
+      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:usermanagement}?authSource=${AUTH_SOURCE:admin}&retryWrites=false
+      auto-index-creation: true
+      uuid-representation: standard
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/DockerImageNames.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/DockerImageNames.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2025 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,34 +21,14 @@
 
 package uk.nhs.tis.trainee.usermanagement;
 
-import io.awspring.cloud.sns.core.SnsTemplate;
-import io.awspring.cloud.sqs.operations.SqsTemplate;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeUserManagementApplicationTest {
+/**
+ * Constants for {@link DockerImageName} values used in tests to ensure consistency.
+ */
+public class DockerImageNames {
 
-  // Could not get it working with the standard mocks, so full container it is.
-  @Container
-  @ServiceConnection
-  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
-      DockerImageNames.MONGO);
-
-  @MockitoBean
-  private SnsTemplate snsTemplate;
-
-  @MockitoBean
-  private SqsTemplate sqsTemplate;
-
-  @Test
-  void contextLoads() {
-
-  }
+  public static final DockerImageName LOCALSTACK = DockerImageName.parse("localstack/localstack:3");
+  public static final DockerImageName MONGO = DockerImageName.parse("mongo:5");
+  public static final DockerImageName REDIS = DockerImageName.parse("redis:6");
 }

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/config/MongoConfigurationTest.java
@@ -45,7 +45,7 @@ class MongoConfigurationTest {
 
     event = configuration.accountEventBeforeConvertCallback().onBeforeConvert(event, "");
 
-    assertThat("Unexpected form ID.", event.id(), notNullValue());
+    assertThat("Unexpected event ID.", event.id(), notNullValue());
   }
 
   @Test
@@ -55,6 +55,6 @@ class MongoConfigurationTest {
 
     event = configuration.accountEventBeforeConvertCallback().onBeforeConvert(event, "");
 
-    assertThat("Unexpected form ID.", event.id(), is(uuid));
+    assertThat("Unexpected event ID.", event.id(), is(uuid));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/config/MongoConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2026 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,36 +19,42 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.tis.trainee.usermanagement;
+package uk.nhs.tis.trainee.usermanagement.config;
 
-import io.awspring.cloud.sns.core.SnsTemplate;
-import io.awspring.cloud.sqs.operations.SqsTemplate;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class TisTraineeUserManagementApplicationTest {
+class MongoConfigurationTest {
 
-  // Could not get it working with the standard mocks, so full container it is.
-  @Container
-  @ServiceConnection
-  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
-      DockerImageNames.MONGO);
+  private MongoConfiguration configuration;
 
-  @MockitoBean
-  private SnsTemplate snsTemplate;
-
-  @MockitoBean
-  private SqsTemplate sqsTemplate;
+  @BeforeEach
+  void setUp() {
+    configuration = new MongoConfiguration();
+  }
 
   @Test
-  void contextLoads() {
+  void shouldPopulateIdBeforeConvertWhenIdNull() {
+    AccountEvent event = AccountEvent.builder().build();
 
+    event = configuration.accountEventBeforeConvertCallback().onBeforeConvert(event, "");
+
+    assertThat("Unexpected form ID.", event.id(), notNullValue());
+  }
+
+  @Test
+  void shouldNotModifyIdBeforeConvertWhenIdPopulated() {
+    UUID uuid = UUID.randomUUID();
+    AccountEvent event = AccountEvent.builder().id(uuid).build();
+
+    event = configuration.accountEventBeforeConvertCallback().onBeforeConvert(event, "");
+
+    assertThat("Unexpected form ID.", event.id(), is(uuid));
   }
 }

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListenerIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/event/ContactDetailsListenerIntegrationTest.java
@@ -1,0 +1,188 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.event;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.when;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+import com.redis.testcontainers.RedisContainer;
+import io.awspring.cloud.sns.core.SnsTemplate;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserNotFoundException;
+import uk.nhs.tis.trainee.usermanagement.DockerImageNames;
+import uk.nhs.tis.trainee.usermanagement.dto.UserAccountDetailsDto;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent.AccountEventDetail;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent.EmailUpdatedDetail;
+import uk.nhs.tis.trainee.usermanagement.service.CognitoService;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+class ContactDetailsListenerIntegrationTest {
+
+  private static final String CONTACT_DETAILS_QUEUE = UUID.randomUUID().toString();
+
+  private static final String USER_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String USER_EMAIL_OLD = "old@example.com";
+  private static final String USER_EMAIL_NEW = "new@example.com";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Container
+  private static final LocalStackContainer localstack = new LocalStackContainer(
+      DockerImageNames.LOCALSTACK)
+      .withServices(SQS);
+
+  @Container
+  private static final RedisContainer redisContainer = new RedisContainer(DockerImageNames.REDIS);
+
+  @DynamicPropertySource
+  private static void overrideProperties(DynamicPropertyRegistry registry) {
+    registry.add("application.aws.sqs.contact-details.updated", () -> CONTACT_DETAILS_QUEUE);
+
+    registry.add("spring.cloud.aws.region.static", localstack::getRegion);
+    registry.add("spring.cloud.aws.credentials.access-key", localstack::getAccessKey);
+    registry.add("spring.cloud.aws.credentials.secret-key", localstack::getSecretKey);
+    registry.add("spring.cloud.aws.sqs.endpoint",
+        () -> localstack.getEndpointOverride(SQS).toString());
+    registry.add("spring.cloud.aws.sqs.enabled", () -> true);
+
+    registry.add("spring.data.redis.host", redisContainer::getHost);
+    registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+  }
+
+  @BeforeAll
+  static void setUpBeforeAll() throws IOException, InterruptedException {
+    localstack.execInContainer("awslocal sqs create-queue --queue-name", CONTACT_DETAILS_QUEUE);
+  }
+
+  @Autowired
+  private CacheManager cacheManager;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @Autowired
+  private SqsTemplate sqsTemplate;
+
+  @MockitoBean
+  private CognitoService cognitoService;
+
+  @MockitoBean
+  private SnsTemplate snsTemplate;
+
+  private Cache cache;
+
+  @BeforeEach
+  void setUp() {
+    cache = cacheManager.getCache("UserId");
+    Objects.requireNonNull(cache);
+    cache.clear();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    mongoTemplate.findAllAndRemove(new Query(), AccountEvent.class);
+  }
+
+  @Test
+  void shouldStoreAccountEventWhenContactDetailsUpdated() {
+    cache.put(TRAINEE_ID, Set.of(USER_ID));
+
+    UserAccountDetailsDto oldDetails = UserAccountDetailsDto.builder()
+        .id(USER_ID)
+        .traineeId(TRAINEE_ID)
+        .email(USER_EMAIL_OLD)
+        .build();
+
+    when(cognitoService.getUserDetails(USER_ID)).thenReturn(oldDetails);
+    when(cognitoService.getUserDetails(USER_EMAIL_NEW)).thenThrow(UserNotFoundException.class);
+
+    String message = """
+        {
+          "record": {
+            "data": {
+              "id": "%s",
+              "email": "%s"
+            }
+          }
+        }
+        """.formatted(TRAINEE_ID, USER_EMAIL_NEW);
+
+    sqsTemplate.send(CONTACT_DETAILS_QUEUE, message);
+
+    Criteria criteria = Criteria.where("userId").is(USER_ID);
+    Query query = Query.query(criteria);
+
+    await()
+        .pollInterval(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
+        .untilAsserted(() -> {
+          AccountEvent found = mongoTemplate.findOne(query, AccountEvent.class);
+          assertThat("No account event found.", found, notNullValue());
+
+          AccountEventDetail eventDetail = found.detail();
+          assertThat("Unexpected event detail type.", eventDetail,
+              instanceOf(EmailUpdatedDetail.class));
+
+          EmailUpdatedDetail emailUpdatedDetail = (EmailUpdatedDetail) eventDetail;
+          assertThat("Unexpected old email.", emailUpdatedDetail.before(), is(USER_EMAIL_OLD));
+          assertThat("Unexpected new email.", emailUpdatedDetail.after(), is(USER_EMAIL_NEW));
+        });
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/repository/AccountEventRepositoryIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/repository/AccountEventRepositoryIntegrationTest.java
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.repository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.mongodb.client.FindIterable;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexField;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.tis.trainee.usermanagement.DockerImageNames;
+import uk.nhs.tis.trainee.usermanagement.config.MongoConfiguration;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent;
+
+@DataMongoTest
+@Import(MongoConfiguration.class)
+@ActiveProfiles("test")
+@Testcontainers
+class AccountEventRepositoryIntegrationTest {
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @BeforeEach
+  void setUp() {
+    template.findAllAndRemove(new Query(), AccountEvent.class);
+  }
+
+  @Autowired
+  private MongoTemplate template;
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      _id_      | _id
+      userId    | userId
+      traineeId | traineeId
+      """)
+  void shouldCreateSingleFieldIndexes(String indexName, String fieldName) {
+    IndexOperations indexOperations = template.indexOps(AccountEvent.class);
+    List<IndexInfo> indexes = indexOperations.getIndexInfo();
+
+    assertThat("Unexpected index count.", indexes, hasSize(3));
+
+    IndexInfo index = indexes.stream()
+        .filter(i -> i.getName().equals(indexName))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Expected index not found."));
+
+    List<IndexField> indexFields = index.getIndexFields();
+    assertThat("Unexpected index field count.", indexFields, hasSize(1));
+
+    IndexField indexField = indexFields.get(0);
+    assertThat("Unexpected index field key.", indexField.getKey(), is(fieldName));
+    assertThat("Unexpected index field direction.", indexField.getDirection(), is(ASC));
+
+    assertThat("Unexpected hidden index.", index.isHidden(), is(false));
+    assertThat("Unexpected hashed index.", index.isHashed(), is(false));
+    assertThat("Unexpected sparse index.", index.isSparse(), is(false));
+    assertThat("Unexpected unique index.", index.isUnique(), is(false));
+    assertThat("Unexpected wildcard index.", index.isWildcard(), is(false));
+  }
+
+  @Test
+  void shouldStoreWithUuidIdType() throws JsonProcessingException {
+    AccountEvent event = AccountEvent.builder().build();
+    template.insert(event);
+
+    String document = template.execute(AccountEvent.class, collection -> {
+      FindIterable<Document> documents = collection.find();
+      return documents.cursor().next().toJson();
+    });
+
+    ObjectNode jsonDocument = (ObjectNode) new ObjectMapper().readTree(document);
+
+    String idType = jsonDocument.get("_id").get("$binary").get("subType").textValue();
+    assertThat("Unexpected ID format.", idType, is("04"));
+  }
+
+  @Test
+  void shouldSetCreatedWhenInserted() {
+    AccountEvent event = AccountEvent.builder().build();
+    template.insert(event);
+
+    List<AccountEvent> savedRecords = template.find(new Query(), AccountEvent.class);
+    assertThat("Unexpected saved records.", savedRecords.size(), is(1));
+    AccountEvent savedRecord = savedRecords.get(0);
+    assertThat("Unexpected saved record id.", savedRecord.id(), notNullValue());
+    Instant roughlyNow = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+    Instant roughlyCreated = savedRecord.created().truncatedTo(ChronoUnit.SECONDS);
+    assertThat("Unexpected saved record created timestamp.", roughlyCreated.equals(roughlyNow),
+        is(true));
+  }
+}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/AuditServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/AuditServiceTest.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.tis.trainee.usermanagement.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static uk.nhs.tis.trainee.usermanagement.model.AccountEventType.EMAIL_UPDATED;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent;
+import uk.nhs.tis.trainee.usermanagement.model.AccountEvent.EmailUpdatedDetail;
+import uk.nhs.tis.trainee.usermanagement.repository.AccountEventRepository;
+
+class AuditServiceTest {
+
+  private static final String USER_ID = UUID.randomUUID().toString();
+  private static final String TRAINEE_ID = "TraineeId123";
+  private static final String EMAIL = "trainee@example.com";
+
+
+  private AuditService service;
+
+  private AccountEventRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(AccountEventRepository.class);
+    service = new AuditService(repository);
+  }
+
+  @Test
+  void shouldCreateEmailUpdatedAuditEvent() {
+    service.accountEmailUpdated(USER_ID, TRAINEE_ID, EMAIL, "new.trainee@example.com");
+
+    ArgumentCaptor<AccountEvent> eventCaptor = ArgumentCaptor.captor();
+    verify(repository).insert(eventCaptor.capture());
+
+    AccountEvent event = eventCaptor.getValue();
+    assertThat("Unexpected event ID.", event.id(), nullValue());
+    assertThat("Unexpected user ID.", event.userId(), is(USER_ID));
+    assertThat("Unexpected trainee ID.", event.traineeId(), is(TRAINEE_ID));
+    assertThat("Unexpected event type.", event.type(), is(EMAIL_UPDATED));
+    assertThat("Unexpected event detail type.", event.detail(),
+        instanceOf(EmailUpdatedDetail.class));
+    assertThat("Unexpected event timestamp.", event.created(), nullValue());
+
+    EmailUpdatedDetail eventDetail = (EmailUpdatedDetail) event.detail();
+    assertThat("Unexpected old email.", eventDetail.before(), is(EMAIL));
+    assertThat("Unexpected new email.", eventDetail.after(), is("new.trainee@example.com"));
+  }
+
+}

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/EventPublishServiceTest.java
@@ -136,7 +136,7 @@ class EventPublishServiceTest {
     assertThat("Unexpected subject.", headers.get(NOTIFICATION_SUBJECT_HEADER),
         is("Profile Data Move"));
     assertThat("Unexpected group ID.", headers.get(MESSAGE_GROUP_ID_HEADER),
-        is(String.format("%s_%s", fromTisId, toTisId))) ;
+        is(String.format("%s_%s", fromTisId, toTisId)));
     assertThat("Unexpected producer.", headers.get("producer"), is("tis-trainee-user-management"));
     verifyNoInteractions(metricsService);
   }

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceIntegrationTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.redis.testcontainers.RedisContainer;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.util.List;
 import java.util.Set;
@@ -39,21 +40,27 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.ListUsersResponse;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.UserType;
+import uk.nhs.tis.trainee.usermanagement.DockerImageNames;
 
-@SpringBootTest(properties = {"embedded.containers.enabled=true", "embedded.redis.enabled=true"})
-@ActiveProfiles({"redis", "test"})
-@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
 @ExtendWith(MockitoExtension.class)
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 class UserAccountServiceIntegrationTest {
@@ -63,6 +70,20 @@ class UserAccountServiceIntegrationTest {
 
   private static final String ATTRIBUTE_TRAINEE_ID = "custom:tisId";
   private static final String ATTRIBUTE_USER_ID = "sub";
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Container
+  private static final RedisContainer redisContainer = new RedisContainer(DockerImageNames.REDIS);
+
+  @DynamicPropertySource
+  private static void registerRedisProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.redis.host", redisContainer::getHost);
+    registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+  }
 
   @MockitoBean
   private CognitoIdentityProviderClient cognitoClient;

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
@@ -106,6 +106,7 @@ class UserAccountServiceTest {
   private UserAccountService service;
   private CognitoService cognitoService;
   private Cache cache;
+  private AuditService auditService;
   private EventPublishService eventPublishService;
   private MetricsService metricsService;
 
@@ -117,11 +118,12 @@ class UserAccountServiceTest {
     CacheManager cacheManager = mock(CacheManager.class);
     when(cacheManager.getCache("UserId")).thenReturn(cache);
 
+    auditService = mock(AuditService.class);
     eventPublishService = mock(EventPublishService.class);
     metricsService = mock(MetricsService.class);
 
     service = spy(new UserAccountService(cognitoService, USER_POOL_ID, cacheManager,
-        eventPublishService, metricsService));
+        eventPublishService, metricsService, auditService));
   }
 
   @Test
@@ -251,6 +253,33 @@ class UserAccountServiceTest {
 
     verify(eventPublishService).publishEmailUpdateEvent(USER_ID_1, TRAINEE_ID_1, previousEmail,
         newEmail);
+  }
+
+  @Test
+  void shouldSaveEventAfterUpdatingEmail() {
+    String previousEmail = "previous.email@example.com";
+    String newEmail = "new.email@example.com";
+
+    UserAccountDetailsDto userDetails = UserAccountDetailsDto.builder()
+        .id(USER_ID_1)
+        .email(previousEmail)
+        .traineeId(TRAINEE_ID_1)
+        .build();
+
+    ArgumentCaptor<String> usernameCaptor = ArgumentCaptor.captor();
+    when(cognitoService.getUserDetails(usernameCaptor.capture()))
+        .thenThrow(UserNotFoundException.class)
+        .thenReturn(userDetails);
+
+    service.updateContactDetails(USER_ID_1, newEmail, FORENAMES_1, SURNAME_1);
+
+    List<String> usernames = usernameCaptor.getAllValues();
+    assertThat("Unexpected get user details request count.", usernames.size(), is(2));
+
+    String username = usernames.get(1);
+    assertThat("Unexpected username.", username, is(USER_ID_1));
+
+    verify(auditService).accountEmailUpdated(USER_ID_1, TRAINEE_ID_1, previousEmail, newEmail);
   }
 
   @ParameterizedTest

--- a/src/test/resources/application-redis.yml
+++ b/src/test/resources/application-redis.yml
@@ -1,7 +1,0 @@
-spring:
-  data:
-    redis:
-      host: ${embedded.redis.host}
-      port: ${embedded.redis.port}
-      user: ${embedded.redis.user}
-      password: ${embedded.redis.password}

--- a/src/test/resources/bootstrap.properties
+++ b/src/test/resources/bootstrap.properties
@@ -1,2 +1,0 @@
-embedded.containers.enabled=false
-embedded.redis.enabled=false


### PR DESCRIPTION
Create an AccountEvent collection and persist the details of an account's email change.
The initial work is simply to record these events as we open them up to trainees self-updating their email. There is no API required at this point.

Future events could include
 - Account creation
 - Account deletion
 - MFA resets
 - Group enrollment/withdrawl

TIS21-2765
TIS21-8539