### PR TITLE
fix: database and collection naming

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.6.0"
+version = "2.6.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/model/AccountEvent.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/model/AccountEvent.java
@@ -41,7 +41,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
  *                  an email update event.
  * @param created   The time the event occurred.
  */
-@Document
+@Document("AccountEvent")
 @Builder
 public record AccountEvent(
     @Id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
         namespace: TIS/Trainee/UserManagement
   data:
     mongodb:
-      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:usermanagement}?authSource=${AUTH_SOURCE:admin}&retryWrites=false
+      uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:user_management}?authSource=${AUTH_SOURCE:admin}&retryWrites=false
       auto-index-creation: true
       uuid-representation: standard
     redis:


### PR DESCRIPTION
Rename the database from `usermanagement` to `user_management` to make it more readable.
Rename the collection from `accountEvent` to `AccountEvent` to fit with existing usage by other services.

TIS21-2765
TIS21-8539