### PR TITLE
fix: get existing user details before updating

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.tis.trainee"
-version = "2.6.1"
+version = "2.6.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
+++ b/src/main/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountService.java
@@ -154,15 +154,16 @@ public class UserAccountService {
         throw new IllegalArgumentException(message);
       }
     } catch (UserNotFoundException e) {
+      UserAccountDetailsDto existingUser = getUserAccountDetails(userId);
+      String traineeId = existingUser.getTraineeId();
+      String existingEmail = existingUser.getEmail();
+
       // If an existing user was not found then the new email address can be used.
       attributeTypes.add(AttributeType.builder().name(ATTRIBUTE_EMAIL).value(newEmail).build());
       attributeTypes.add(
           AttributeType.builder().name(ATTRIBUTE_EMAIL_VERIFIED).value("true").build());
       cognitoService.updateAttributes(userId, attributeTypes);
 
-      UserAccountDetailsDto existingUser = getUserAccountDetails(userId);
-      String traineeId = existingUser.getTraineeId();
-      String existingEmail = existingUser.getEmail();
       auditService.accountEmailUpdated(userId, traineeId, existingEmail, newEmail);
       eventPublishService.publishEmailUpdateEvent(userId, traineeId, existingEmail, newEmail);
       log.info("Successfully updated email to '{}' for user '{}'.", newEmail, userId);

--- a/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
+++ b/src/test/java/uk/nhs/tis/trainee/usermanagement/service/UserAccountServiceTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminAddUserToGroupRequest;
@@ -253,6 +255,29 @@ class UserAccountServiceTest {
 
     verify(eventPublishService).publishEmailUpdateEvent(USER_ID_1, TRAINEE_ID_1, previousEmail,
         newEmail);
+  }
+
+  @Test
+  void shouldGetExistingDetailsBeforeUpdatingEmail() {
+    String previousEmail = "previous.email@example.com";
+    String newEmail = "new.email@example.com";
+
+    UserAccountDetailsDto userDetails = UserAccountDetailsDto.builder()
+        .id(USER_ID_1)
+        .email(previousEmail)
+        .traineeId(TRAINEE_ID_1)
+        .build();
+
+    when(cognitoService.getUserDetails(any()))
+        .thenThrow(UserNotFoundException.class)
+        .thenReturn(userDetails);
+
+    service.updateContactDetails(USER_ID_1, newEmail, FORENAMES_1, SURNAME_1);
+
+    InOrder inOrder = inOrder(cognitoService);
+    inOrder.verify(cognitoService).getUserDetails("new.email@example.com");
+    inOrder.verify(cognitoService).getUserDetails(USER_ID_1);
+    inOrder.verify(cognitoService).updateAttributes(eq(USER_ID_1), any());
   }
 
   @Test


### PR DESCRIPTION
The UserAccountService saves audit data and publishes an event when an account email is changed.
Currently, the account is updated before retrieving the existing user details. So the resulting audit and event contains the new email instead of the original email.

Update the ordering of the user lookup and update to ensure the original details can be retained.

TIS21-2765
TIS21-8539